### PR TITLE
Add Theme Templates Feature

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,10 +25,10 @@ This will generate the directory /tmp/onoffice with the plugin data. If you need
 ## Getting Started
 
 1. Move the plugin directory into a new subdirectory inside the WordPress plugins directory (`wp-content/plugins/`)
-2. Create a new plugin folder called `onoffice-personalized`.
-3. Copy the folder `templates.dist` to `onoffice-personalized/templates`. This is where the newly created individual templates will go.
+2. Create a new plugin folder called `onoffice-personalized` or create a new folder inside your theme called `onoffice-theme`.
+3. Copy the folder `templates.dist` to `onoffice-personalized/templates` or `onoffice-theme/templates`. This is where the newly created individual templates will go.
 4. Login into your WordPress page as an administrator and go to the plugins list by navigating to `Plugins` » `Installed Plugins`. You should be able to see and activate the onOffice for WP-Websites plugin. If no API token or secret have been saved so far, a notification will show up at the top. Clicking the link will bring you to the appropriate configuration page.
-5. Start editing inside the new `onoffice-personalized` folder.
+5. Start editing inside the new `onoffice-personalized` or `onoffice-theme` folder.
 
 **IMPORTANT**: Although it is safe to disable the plugin, DELETING IT WILL WIPE ALL PLUGIN-RELATED DATA FROM THE DATABASE. WE DO NOT PROVIDE ANY WARRANTY FOR DATA LOSS!
 

--- a/plugin.php
+++ b/plugin.php
@@ -112,7 +112,14 @@ add_action('plugins_loaded', function() {
 	// Check 'onoffice-personalized' Folder exists
 	$onofficePersonalizedFolderLanguages = plugin_dir_path(__DIR__) . 'onoffice-personalized/languages';
 	$onofficePersonalizedFolder = plugin_dir_path(__DIR__) . 'onoffice-personalized';
-	if (is_dir($onofficePersonalizedFolderLanguages)) {
+	// Check 'onoffice-theme' Folder exists
+	$onofficeThemeFolderLanguages = get_template_directory() . '/onoffice-theme/languages';
+	$onofficeThemeFolder = get_template_directory() . '/onoffice-theme';
+
+	if (is_dir($onofficeThemeFolderLanguages)) {
+		load_textdomain('onoffice', $onofficeThemeFolder.'/languages/onoffice-'.get_locale().'.mo');
+		load_textdomain('onoffice-for-wp-websites', $onofficeThemeFolder.'/languages/onoffice-for-wp-websites-'.get_locale().'.mo');
+	} elseif (is_dir($onofficePersonalizedFolderLanguages)) {
 		load_plugin_textdomain('onoffice', false, basename($onofficePersonalizedFolder) . '/languages');
 	} else {
 		load_plugin_textdomain('onoffice', false, basename(ONOFFICE_PLUGIN_DIR) . '/languages');

--- a/plugin/Model/FormModelBuilder/FormModelBuilder.php
+++ b/plugin/Model/FormModelBuilder/FormModelBuilder.php
@@ -119,12 +119,20 @@ abstract class FormModelBuilder
 			.'templates.dist/'.$directory.'/'.$pattern.'.php');
 		$templateLocalFiles = glob(plugin_dir_path(ONOFFICE_PLUGIN_DIR)
 			.'onoffice-personalized/templates/'.$directory.'/'.$pattern.'.php');
-		$templatesAll = array_merge($templateGlobFiles, $templateLocalFiles);
+			$templateThemeFiles = glob(get_template_directory()
+			.'/onoffice-theme/templates/'.$directory.'/'.$pattern.'.php');
+		
+		$templatesAll = array_merge($templateGlobFiles, $templateLocalFiles, $templateThemeFiles);
 		$templates = array();
 
 		foreach ($templatesAll as $value) {
-			$value = __String::getNew($value)->replace(plugin_dir_path(ONOFFICE_PLUGIN_DIR), '');
-			$templates[$value] = $value;
+			if(strpos($value, 'themes') !== false) {
+				$value = __String::getNew($value)->replace(get_template_directory().'/', '');
+				$templates[$value] = $value;
+			}else{
+				$value = __String::getNew($value)->replace(plugin_dir_path(ONOFFICE_PLUGIN_DIR), '');
+				$templates[$value] = $value;
+			}
 		}
 
 		return $templates;

--- a/plugin/Template.php
+++ b/plugin/Template.php
@@ -122,6 +122,9 @@ class Template
 	 */
 	protected function buildFilePath(): string
 	{
+		if(strpos($this->_templateName, 'onoffice-theme') !== false) {
+			return get_template_directory().'/'.$this->_templateName;
+		}
 		return WP_PLUGIN_DIR.'/'.$this->_templateName;
 	}
 


### PR DESCRIPTION
General convention to use the theme folder for plugin template files. https://deliciousbrains.com/wordpress-plugin-development-template-files/#overriding-plugin-templates

Create a folder inside your WP Theme called `onoffice-theme` and create a folder inside of it called `templates`. Copy the templates from `templates.dist` and use it as your custom templates folder.

I've edited the readme to include the Theme Template feature. 