### PR TITLE
Rebuild release actions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,69 @@
+name: Build Release
+
+on:
+  workflow_call:
+    inputs: 
+      ref:
+        description: "The ref to check out. When not given, we use actions/checkout@v2's default behavior."
+        type: string
+        required: false
+        default: ''
+      expectedVersion:
+        description: "The version that should be present in the config files like readme.txt and plugin.php."
+        type: string
+        required: true
+      overrideVersion:
+        description: "A version to set in plugin.php after the build. Useful for development versions."
+        type: string
+        required: false
+        default: ''
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout from GIT
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Check version
+        run: deno run --allow-read scripts/check-version-in-config-files.ts ${{ inputs.expectedVersion }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.0
+          extensions: mbstring, mysqli, intl, curl
+
+      - name: Install development dependencies
+        run: composer install
+
+      - name: Build release
+        run: PREFIX=/tmp/release make unprocessed-release
+
+      - run: cat /tmp/release/onoffice/plugin.php
+
+      - name: Override version
+        if: ${{ inputs.overrideVersion != '' }}
+        run: 'sed -i "s/Version: ${{ inputs.expectedVersion }}/Version: ${{ inputs.overrideVersion }}/" /tmp/release/onoffice/plugin.php'
+
+      - run: cat /tmp/release/onoffice/plugin.php
+
+      - name: Zip release
+        run: |
+          cd /tmp/release/onoffice
+          zip -r ../release.zip .
+
+      - name: Upload release as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: release
+          path: /tmp/release/release.zip
+

--- a/.github/workflows/development-release.yml
+++ b/.github/workflows/development-release.yml
@@ -84,5 +84,5 @@ jobs:
         # With 'awk' we extract each file name and transform it into the right command, and 'xargs' executes each such command.
         run: svn status | grep ^! | awk '{$1=""; print " --force \""substr($0,2)"@\"" }' | xargs -r svn rm
 
-      - run: svn status
+      - run: svn diff
         working-directory: /tmp/svn

--- a/.github/workflows/development-release.yml
+++ b/.github/workflows/development-release.yml
@@ -1,0 +1,88 @@
+name: Development Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  get-versions:
+    name: Get versions
+    runs-on: ubuntu-latest
+    outputs:
+      stableVersion: ${{ steps.get-stable-version.outputs.stableVersion }}
+      developmentVersion: ${{ steps.get-development-version.outputs.developmentVersion }}
+    steps:
+      - name: Checkout from GIT
+        uses: actions/checkout@v2
+        with:
+          # We need to fetch more than just the most recent commit,
+          # since we later use `git describe`.
+          fetch-depth: 0
+          
+      - name: Get latest stable plugin version (without leading 'v')
+        id: get-stable-version
+        # Remove the leading 'v' from the tag.
+        run: echo "::set-output name=stableVersion::$( git describe --tags --abbrev=0 | sed -n 's/v\(\)/\1/p')"
+
+      - name: Output development version
+        id: get-development-version
+        # Remove the leading 'v'.
+        run: echo "::set-output name=developmentVersion::$( git describe --tags | sed -n 's/v\(\)/\1/p')"
+
+  build:
+    name: Build release
+    needs: get-versions
+    uses: ./.github/workflows/build-release.yml
+    with:
+      expectedVersion: ${{ needs.get-versions.outputs.stableVersion }}
+      overrideVersion: ${{ needs.get-versions.ouputs.developmentVersion }}
+  
+  dev-release:
+    name: Development release
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      SVN_URL: https://plugins.svn.wordpress.org/onoffice-for-wp-websites
+    steps:
+      - name: Download release
+        uses: actions/download-artifact@v3
+        with:
+          name: release
+          path: /tmp/release
+
+      - name: Unzip release
+        working-directory: /tmp/release
+        run: |
+          unzip release.zip
+          rm release.zip
+
+      - name: Make directory for updating SVN
+        run: mkdir /tmp/svn
+
+      - name: Checkout current trunk
+        working-directory: /tmp/svn
+        run: svn co ${{ env.SVN_URL }}/trunk .
+
+      - name: Remove all files
+        working-directory: /tmp/svn
+        # Files that were removed should also be removed from SVN.
+        # To be able to see which files need to be removed, we clean out everything except the '.svn/' folder.
+        run: find . ! -path '.' ! -path './.svn*' -delete
+
+      - name: Copy release files
+        working-directory: /tmp/svn
+        run: cp -r /tmp/release/* .
+
+      - name: Add all files to SVN
+        working-directory: /tmp/svn
+        run: svn add --force .
+
+      - name: Inform SVN about removed files
+        working-directory: /tmp/svn
+        # SVN does not automatically detect which files were removed.
+        # 'svn status' returns a list of changed files and "missing" files are marked with a '!' at the beginning of the line.
+        # We apply 'svn rm --force <file path>' on each of those "missing" files so that SVN knows to remove them.
+        # With 'awk' we extract each file name and transform it into the right command, and 'xargs' executes each such command.
+        run: svn status | grep ^! | awk '{$1=""; print " --force \""substr($0,2)"@\"" }' | xargs -r svn rm
+
+      - run: svn status
+        working-directory: /tmp/svn

--- a/.github/workflows/development-zip.yml
+++ b/.github/workflows/development-zip.yml
@@ -34,7 +34,7 @@ jobs:
     name: Build development release
     needs: get-versions
     # We cannot use a relative path here, or GitHub Actions does not find the workflow. This might be a bug in GitHub Actions.
-    uses: jmaas-onoffice/oo-wp-plugin/.github/workflows/build-release.yml@master
+    uses: onOfficeGmbH/oo-wp-plugin/.github/workflows/build-release.yml@master
     with:
       # The trigger makes this run on a merge commit, but we want to run
       # on the latest commit before the review.

--- a/.github/workflows/development-zip.yml
+++ b/.github/workflows/development-zip.yml
@@ -1,0 +1,80 @@
+name: Share development zip
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  get-versions:
+    if: github.event.review.state == 'approved'
+    name: Get versions
+    runs-on: ubuntu-latest
+    outputs:
+      stableVersion: ${{ steps.get-stable-version.outputs.stableVersion }}
+      developmentVersion: ${{ steps.get-development-version.outputs.developmentVersion }}
+    steps:
+      - name: Checkout from GIT
+        uses: actions/checkout@v2
+        with:
+          # We need to fetch more than just the most recent commit,
+          # since we later use `git describe`.
+          fetch-depth: 0
+          
+      - name: Get latest stable plugin version (without leading 'v')
+        id: get-stable-version
+        # Remove the leading 'v' from the tag.
+        run: echo "::set-output name=stableVersion::$( git describe --tags --abbrev=0 | sed -n 's/v\(\)/\1/p')"
+
+      - name: Output development version
+        id: get-development-version
+        # Remove the leading 'v'.
+        run: echo "::set-output name=developmentVersion::$( git describe --tags | sed -n 's/v\(\)/\1/p')"
+
+  dev-build:
+    name: Build development release
+    needs: get-versions
+    # We cannot use a relative path here, or GitHub Actions does not find the workflow. This might be a bug in GitHub Actions.
+    uses: jmaas-onoffice/oo-wp-plugin/.github/workflows/build-release.yml@master
+    with:
+      # The trigger makes this run on a merge commit, but we want to run
+      # on the latest commit before the review.
+      ref: ${{ github.event.pull_request.head.sha }}
+      expectedVersion: ${{ needs.get-versions.outputs.stableVersion }}
+      overrideVersion: ${{ needs.get-versions.outputs.developmentVersion }}
+  
+  comment:
+    name: Pack a development zip and comment on the PR
+    runs-on: ubuntu-latest
+    needs: [get-versions, dev-build]
+    steps:
+      - name: Download release
+        uses: actions/download-artifact@v3
+        with:
+          name: release
+          path: /tmp/release/onoffice-for-wp-websites
+
+      - name: Unzip release
+        working-directory: /tmp/release/onoffice-for-wp-websites/
+        run: |
+          unzip release.zip
+          rm release.zip
+
+      - name: Create development zip
+        working-directory: /tmp/release/  # To prevent nested paths (like /tmp/release/onoffice/readme.txt) we need to be in this directory.
+        run: zip -r ./onoffice-${{ needs.get-versions.outputs.developmentVersion }}.zip ./onoffice-for-wp-websites/ 
+
+      - name: Upload development zip
+        uses: actions/upload-artifact@v3
+        with:
+          name: onoffice-${{ needs.get-versions.outputs.developmentVersion }}-please-unpack
+          path: /tmp/release/onoffice-${{ needs.get-versions.outputs.developmentVersion }}.zip  # Uploading a .zip leads to a .zip inside a .zip, but uploading the folder takes significantly longer.
+
+      - name: Post comment to PR
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            Install the approved version:
+            1. Download `onoffice-${{ needs.get-versions.outputs.developmentVersion }}-please-unpack.zip` from https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+            2. Unpack the downloaded file to get another .zip file.
+            3. Upload that inner .zip file to WordPress.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -72,5 +72,5 @@ jobs:
         # With 'awk' we extract each file name and transform it into the right command, and 'xargs' executes each such command.
         run: svn status | grep ^! | awk '{$1=""; print " --force \""substr($0,2)"@\"" }' | xargs -r svn rm
 
-      - run: svn status
+      - run: svn diff
         working-directory: /tmp/svn

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,0 +1,76 @@
+name: Stable Release
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  get-version:
+    name: Get current version
+    runs-on: ubuntu-latest
+    outputs:
+      currentVersion: ${{ steps.get-version.outputs.version }}
+    steps:
+      - name: Get version
+        id: get-version
+        # Remove the leading 'v' from the tag.
+        run: echo "::set-output name=version::$(echo ${{ github.ref_name }} | sed -n 's/v\(\)/\1/p')"
+
+  build:
+    name: Build release
+    needs: get-version
+    uses: ./.github/workflows/build-release.yml
+    with:
+      expectedVersion: ${{ needs.get-version.outputs.currentVersion }}
+
+  deploy:
+    name: Deploy to WordPress SVN
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      SVN_URL: https://plugins.svn.wordpress.org/onoffice-for-wp-websites
+    steps:
+      - name: Download release
+        uses: actions/download-artifact@v3
+        with:
+          name: release
+          path: /tmp/release
+
+      - name: Unzip release
+        working-directory: /tmp/release
+        run: |
+          unzip release.zip
+          rm release.zip
+
+      - name: Make directory for updating SVN
+        run: mkdir /tmp/svn
+
+      - name: Checkout current trunk
+        working-directory: /tmp/svn
+        run: svn co ${{ env.SVN_URL }}/trunk .
+
+      - name: Remove all files
+        working-directory: /tmp/svn
+        # Files that were removed should also be removed from SVN.
+        # To be able to see which files need to be removed, we clean out everything except the '.svn/' folder.
+        run: find . ! -path '.' ! -path './.svn*' -delete
+
+      - name: Copy release files
+        working-directory: /tmp/svn
+        run: cp -r /tmp/release/* .
+
+      - name: Add all files to SVN
+        working-directory: /tmp/svn
+        run: svn add --force .
+
+      - name: Inform SVN about removed files
+        working-directory: /tmp/svn
+        # SVN does not automatically detect which files were removed.
+        # 'svn status' returns a list of changed files and "missing" files are marked with a '!' at the beginning of the line.
+        # We apply 'svn rm --force <file path>' on each of those "missing" files so that SVN knows to remove them.
+        # With 'awk' we extract each file name and transform it into the right command, and 'xargs' executes each such command.
+        run: svn status | grep ^! | awk '{$1=""; print " --force \""substr($0,2)"@\"" }' | xargs -r svn rm
+
+      - run: svn status
+        working-directory: /tmp/svn

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 
 copy-files-release:
 	install -d $(PREFIX)/onoffice
-	find * -type f \( ! -path "bin/*" ! -path "build/*" ! -path "vendor/bin/*" ! -path "./.*" ! -path "nbproject/*"  ! -path "tests/*" ! -iname ".*" ! -iname "Readme.md" ! -iname "phpstan.neon" ! -iname "phpstan-baseline.neon" ! -iname "phpunit.xml*" ! -iname "Makefile" ! -iname "phpcs.xml*" \) -exec install -v -D -T ./{} $(PREFIX)/onoffice/{} \;
+	find * -type f \( ! -path "bin/*" ! -path "build/*" ! -path "vendor/bin/*" ! -path "./.*" ! -path "nbproject/*"  ! -path "tests/*" ! -path "scripts/*" ! -iname ".*" ! -iname "Readme.md" ! -iname "phpstan.neon" ! -iname "phpstan-baseline.neon" ! -iname "phpunit.xml*" ! -iname "Makefile" ! -iname "phpcs.xml*" \) -exec install -v -D -T ./{} $(PREFIX)/onoffice/{} \;
 
 change-title: copy-files-release
 	sed -i -r "s/(Plugin Name: .+) \(dev\)$$/\1/" $(PREFIX)/onoffice/plugin.php

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ pot:
 
 release: pot copy-files-release change-title add-version composer-install-nodev
 
+unprocessed-release: pot copy-files-release composer-install-nodev
+
 test-zip: pot copy-files-release add-version composer-install-nodev
 	cd $(PREFIX); zip -r onoffice.zip onoffice/
 

--- a/plugin.php
+++ b/plugin.php
@@ -20,12 +20,12 @@
  */
 
 /*
-Plugin Name: onOffice for WP-Websites (dev)
+Plugin Name: onOffice for WP-Websites
 Plugin URI: https://wpplugindoc.onoffice.de
 Author: onOffice GmbH
 Author URI: https://en.onoffice.com/
 Description: Your connection to onOffice: This plugin enables you to have quick access to estates and forms – no additional sync with the software is needed. Consult support@onoffice.de for source code.
-Version: 2.0
+Version: 2.22.4
 License: AGPL 3+
 License URI: https://www.gnu.org/licenses/agpl-3.0
 Text Domain: onoffice-for-wp-websites

--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@ Tags: real estate, onoffice
 Requires at least: 4.6
 Tested up to: 5.9
 Requires PHP: 7.0
+Stable tag: 2.22.4
 License: AGPL 3.0
 License URI: https://www.gnu.org/licenses/agpl-3.0.html
 

--- a/scripts/check-version-in-config-files.ts
+++ b/scripts/check-version-in-config-files.ts
@@ -1,0 +1,80 @@
+await check();
+
+/**
+ * Ensures that the version passed as an argument is formatted correctly and that it is set correctly in the config files (readme.txt and plugin.php).
+ *
+ * Run this script from this repo's root (such that './readme.txt' works) with Deno (https://deno.land/), for example:
+ * $ deno --allow-read scripts/check-version-in-config-files.ts v1.2.3
+ */
+async function check() {
+  if (Deno.args.length !== 1) {
+    console.error(
+      `I expected just the version to check as an argument, but I received ${Deno.args.length} arguments.`,
+    );
+    Deno.exit(1);
+  }
+
+  const newVersion = Deno.args[0];
+  const isValidVersion = /^\d+.\d+.\d+$/.test(newVersion)
+  if (!isValidVersion) {
+    console.error(
+      `The given version '${newVersion} is not valid. The version has to be in the form 'v1.2.3'.`,
+    );
+    Deno.exit(1);
+  }
+
+  const readme = await Deno.readTextFile("./readme.txt");
+
+  const versionInReadme = readme.match(/Stable tag: (.+)\s*$/m)?.at(1);
+  assertValidVersion(
+    versionInReadme,
+    newVersion,
+    `The 'readme.txt' is missing a 'Stable tag'.`,
+    `The 'readme.txt' has a 'Stable tag' with the wrong version. It points to ${versionInReadme}, but the new version is ${newVersion}.`,
+  );
+
+  const versionInChangelog = readme.match(
+    /==\s*Changelog\s*==.*?=\s*(.+?)\s*=/s,
+  )
+    ?.at(1);
+  assertValidVersion(
+    versionInChangelog,
+    newVersion,
+    `Could not find the Changelog in the 'readme.txt'. Make sure there is a line '== Changelog ==' and below it an entry '= ${newVersion} ='.`,
+    `The newest changelog entry in the 'readme.txt' has the wrong version. It points to ${versionInChangelog}, but the new version is ${newVersion}.`,
+  );
+
+  const pluginPhp = await Deno.readTextFile("./plugin.php");
+
+  const versionInPluginPhp = pluginPhp.match(/Version: (.+)/)?.at(1);
+  assertValidVersion(
+    versionInPluginPhp,
+    newVersion,
+    `The 'plugin.php' is missing a 'Version'.`,
+    `The 'plugin.php' has a 'Version' with the wrong version. It points to ${versionInPluginPhp}, but the new version is ${newVersion}.`,
+  );
+
+  console.log(
+    `Success: Version ${newVersion} is set correctly in the 'readme.txt' and the 'plugin.php'.`,
+  );
+}
+
+function assertValidVersion(
+  entry: string | undefined,
+  newVersion: string,
+  errorWhenMissing: string,
+  errorWhenInvalid: string,
+) {
+  if (entry !== newVersion) {
+    if (entry === undefined) {
+      console.error(
+        errorWhenMissing,
+      );
+    } else {
+      console.error(
+        errorWhenInvalid,
+      );
+    }
+    Deno.exit(1);
+  }
+}

--- a/scripts/check-version-in-config-files.ts
+++ b/scripts/check-version-in-config-files.ts
@@ -33,16 +33,24 @@ async function check() {
     `The 'readme.txt' has a 'Stable tag' with the wrong version. It points to ${versionInReadme}, but the new version is ${newVersion}.`,
   );
 
-  const versionInChangelog = readme.match(
-    /==\s*Changelog\s*==.*?=\s*(.+?)\s*=/s,
+  const versionsInChangelog = readme.match(
+    /==\s*Changelog\s*==.*?(?:=\s*(.+?)\s*=.*?)?(?:=\s*(.+?)\s*=)/s,
   )
-    ?.at(1);
-  assertValidVersion(
-    versionInChangelog,
-    newVersion,
+  if (versionsInChangelog === null) {
+    console.error(
     `Could not find the Changelog in the 'readme.txt'. Make sure there is a line '== Changelog ==' and below it an entry '= ${newVersion} ='.`,
-    `The newest changelog entry in the 'readme.txt' has the wrong version. It points to ${versionInChangelog}, but the new version is ${newVersion}.`,
-  );
+    )
+    Deno.exit(1)
+  }
+
+  const newestVersionInChangelog = versionsInChangelog?.at(1);
+  const secondVersionInChangelog = versionsInChangelog?.at(2);
+  if (newestVersionInChangelog !== newVersion && secondVersionInChangelog !== newVersion) {
+    console.error(
+    `The two most recent changelog entries in the 'readme.txt' have the wrong version. They point to ${newestVersionInChangelog} and ${secondVersionInChangelog}, but the new version is ${newVersion}.`,
+    );
+    Deno.exit(1);
+  }
 
   const pluginPhp = await Deno.readTextFile("./plugin.php");
 


### PR DESCRIPTION
- Adds a "Stable tag: <current version>" to readme.txt.
- Uses the official title in plugin.php. (No suffix "(dev)".)
- Adds the current stable version to plugin.php.
- The new development zip installs the plugin into the same folder as the released plugin (/plugins/onoffice-for-wp-websites). But it is distinguishable from the release by its version (it has the commit hash from `git describe --tags`).