### PR TITLE
Test development .zip action

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,8 @@
 # onOffice plugin for WordPress
 ![Unit tests](https://github.com/onOfficeGmbH/oo-wp-plugin/workflows/Unit%20tests/badge.svg?branch=master)
 
+Test
+
 Integrate real estates, contact forms and contact persons from the onOffice Software into your WordPress website.
 
 ## Set up for development


### PR DESCRIPTION
In #253 I couldn't test the development .zip action, because the build always uses the workflow files from `master`.