### PR TITLE
Fix/P#139033 mobile url sharing for estate details

### DIFF
--- a/plugin/Controller/RewriteRuleBuilder.php
+++ b/plugin/Controller/RewriteRuleBuilder.php
@@ -82,8 +82,8 @@ class RewriteRuleBuilder
 	private function setCanonicalUrlFromRequest(array $pageIds)
 	{
 		$canonicalFilters = [
-			'get_canonical_url',                    // WordPress default
-			'wpseo_canonical',                      // Yoast SEO
+			'get_canonical_url', // WordPress default
+			'wpseo_canonical',   // Yoast SEO
 		];
 
 		foreach ($canonicalFilters as $filter) {


### PR DESCRIPTION
This PR sets the full URL for estate details pages in the rel=canonical link tag.
This will fix the problem with the wrong URL sharing on mobile devices. Some plugins might not recognize the rewritten URL by our plugin and simply use the base page url of the short tag. 