### PR TITLE
fix(P#123123): Markdown Function WP-Plugin

### DIFF
--- a/templates.dist/form/applicantform.php
+++ b/templates.dist/form/applicantform.php
@@ -117,12 +117,12 @@ foreach ( $pForm->getInputFields() as $input => $table ) {
 		$errorHtml = renderErrorHtml($errorMessage, $isRequiredMessage);
 		
 		if (!$isHiddenField) {
-			$line = '<label class="' . ($displayError && $isRequired ? ' displayerror' : '') . '">'.$pForm->getFieldLabel( 'message' );
+			$line = '<label class="' . ($displayError && $isRequired ? ' displayerror' : '') . '">'.wp_kses_post($pForm->getFieldLabel( 'message' ));
 			$line .= ' '.$additionMessage;
-			$line .= '<textarea name="message" autocomplete="off"' . ($isRequiredMessage ? ' required aria-required="true" aria-invalid="false"' : '') . '>' . $pForm->getFieldValue('message') . '</textarea>'.$errorHtml.'</label>';
+			$line .= '<textarea name="message" autocomplete="off"' . ($isRequiredMessage ? ' required aria-required="true" aria-invalid="false"' : '') . '>' .esc_textarea($pForm->getFieldValue('message')) . '</textarea>'.$errorHtml.'</label>';
 
 		} else {
-			$line = '<input type="hidden" name="message" value="' . $pForm->getFieldValue('message') . '">';
+			$line = '<input type="hidden" name="message" value="' . esc_attr($pForm->getFieldValue('message')) . '">';
 		}
 	}
 

--- a/templates.dist/form/applicantform.php
+++ b/templates.dist/form/applicantform.php
@@ -74,7 +74,7 @@ foreach ( $pForm->getInputFields() as $input => $table ) {
 	$addition   = $isRequired ? '<span class="oo-visually-hidden">'.esc_html__('Pflichtfeld', 'onoffice-for-wp-websites').'</span><span aria-hidden="true">*</span>' : '';
 	$searchcriteriaLine = '';
 	$isHiddenField = $pForm->isHiddenField($input);
-	$label = $pForm->getFieldLabel($input);
+	$label = wp_kses_post($pForm->getFieldLabel($input));
 
 
 	if ( in_array( $input, array( 'kaufpreis','kaltmiete','wohnflaeche','anzahl_zimmer' ) ) ) {
@@ -85,7 +85,7 @@ foreach ( $pForm->getInputFields() as $input => $table ) {
 		if (\onOffice\WPlugin\Types\FieldTypes::FIELD_TYPE_SINGLESELECT== $pForm->getFieldType($input)) {
 			$line =	 !$isHiddenField ? '<div class="oo-single-select"><label for="'.$input.'-ts-control"><span class="oo-label-text' . ($displayError && $isRequired ? ' displayerror' : '') . '">'.$label.' '.$addition.'</span></label>' . renderFormField($input, $pForm).'</div>' : renderFormField($input, $pForm);
 		} else {
-			$line = '<label>'.$pForm->getFieldLabel($input).' '.$addition;
+			$line = '<label>'.$label.' '.$addition;
 			$line .= renderFormField($input, $pForm).'</span></label>';
 		}
 
@@ -106,7 +106,7 @@ foreach ( $pForm->getInputFields() as $input => $table ) {
 
 	if ( in_array( $input, array( 'gdprcheckbox' ) ) ) {
 		$line = '<label><span class="oo-label-text ' . ($displayError && $isRequired ? ' displayerror' : '') . '">';
-		$line .= $pForm->getFieldLabel( 'gdprcheckbox' ) .' </span>'. $addition.renderFormField( 'gdprcheckbox', $pForm ).'</label>';
+		$line .= wp_kses_post($pForm->getFieldLabel( 'gdprcheckbox' )) .' </span>'. $addition.renderFormField( 'gdprcheckbox', $pForm ).'</label>';
 	}
 
 	if ( in_array( $input, array( 'message' )) ) {

--- a/templates.dist/form/applicantformwizard.php
+++ b/templates.dist/form/applicantformwizard.php
@@ -58,12 +58,10 @@ if ($pForm->getFormStatus() === FormPost::MESSAGE_SUCCESS) {
 			echo esc_html(sprintf(__('Please enter a value for %s.', 'onoffice-for-wp-websites'), $pForm->getFieldLabel( $input ))).'<br>';
 		}
 
-		$fieldLabel = $pForm->getFieldLabel($input);
-
 		$isRequired = $pForm->isRequiredField($input);
 		$addition   = $isRequired ? '<span class="oo-visually-hidden">'.esc_html__('Required', 'onoffice-for-wp-websites').'</span><span aria-hidden="true">*</span>' : '';
 		$isHiddenField = $pForm->isHiddenField($input);
-		$label = $fieldLabel.' '.wp_kses_post($addition);
+		$label = wp_kses_post($pForm->getFieldLabel($input)).' '.wp_kses_post($addition);
 
 		if ( in_array( $input, array( 'kaufpreis','kaltmiete','wohnflaeche','anzahl_zimmer' ) ) ) {
 			$line = '<div class="oo-input-wrapper">';

--- a/templates.dist/form/applicantsearchform.php
+++ b/templates.dist/form/applicantsearchform.php
@@ -59,7 +59,7 @@ foreach ( $pForm->getInputFields() as $input => $table ) {
 	$isRequired = $pForm->isRequiredField( $input );
 	$addition   = $isRequired ? '<span class="oo-visually-hidden">'.esc_html__('Pflichtfeld', 'onoffice-for-wp-websites').'</span><span aria-hidden="true">*</span>' : '';
 	$inputAddition = $isRequired ? ' required' : '';
-	$label = esc_html($pForm->getFieldLabel($input)) . ' ' . wp_kses_post($addition);
+	$label = wp_kses_post($pForm->getFieldLabel($input)) . ' ' . wp_kses_post($addition);
 	
 	$permittedValues = $pForm->getPermittedValues( $input, true );
 

--- a/templates.dist/form/defaultform.php
+++ b/templates.dist/form/defaultform.php
@@ -83,11 +83,11 @@ if ($pForm->getFormStatus() === onOffice\WPlugin\FormPost::MESSAGE_SUCCESS) {
 			continue;
 		}
 		if ( in_array( $input, array( 'gdprcheckbox' ) ) ) {
-            // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- renderFormField returns escaped HTML
-            echo '<label><span class="oo-label-text ' . ($displayError && $isRequired ? ' displayerror' : '') . '">';
-            echo wp_kses_post($pForm->getFieldLabel( 'gdprcheckbox' )) .' '. wp_kses_post($addition).renderFormField( 'gdprcheckbox', $pForm ).'</span></label>';
-            continue;
-        }
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- renderFormField returns escaped HTML
+			echo '<label><span class="oo-label-text ' . ($displayError && $isRequired ? ' displayerror' : '') . '">';
+			echo wp_kses_post($pForm->getFieldLabel( 'gdprcheckbox' )) .' '. wp_kses_post($addition).renderFormField( 'gdprcheckbox', $pForm ).'</span></label>';
+			continue;
+		}
 		if ( in_array( $input, array( 'message' ) ) ) {
 			$isRequiredMessage = $pForm->isRequiredField( 'message' );
 			$additionMessage   = $isRequiredMessage ? '<span class="oo-visually-hidden">'.esc_html__('Pflichtfeld', 'onoffice-for-wp-websites').'</span><span aria-hidden="true">*</span>' : '';
@@ -95,26 +95,26 @@ if ($pForm->getFormStatus() === onOffice\WPlugin\FormPost::MESSAGE_SUCCESS) {
 			$errorMessage = esc_html__('Please enter a text.', 'onoffice-for-wp-websites');
 			$errorHtml = renderErrorHtml($errorMessage, $isRequiredMessage);
 
-			 if (!$isHiddenField) {
-                echo  '<label class="' . ($displayError && $isRequired ? ' displayerror' : '') . '">'.esc_html($pForm->getFieldLabel( 'message' ));
-                echo  ' '.wp_kses_post($additionMessage);
-                // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $errorHtml is already escaped from renderErrorHtml
-                echo  '<textarea name="message" data-rule="text" autocomplete="off"' . ($isRequiredMessage ? ' required aria-required="true" aria-invalid="false"' : '') . '>' . esc_textarea($pForm->getFieldValue('message')) . '</textarea>'.$errorHtml.'</label>';
-            } else {
-                echo '<input type="hidden" name="message" value="' . esc_attr($pForm->getFieldValue('message')) . '">';
-            }
-            continue;
+			if (!$isHiddenField) {
+				echo  '<label class="' . ($displayError && $isRequired ? ' displayerror' : '') . '">'.esc_html($pForm->getFieldLabel( 'message' ));
+				echo  ' '.wp_kses_post($additionMessage);
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $errorHtml is already escaped from renderErrorHtml
+				echo  '<textarea name="message" data-rule="text" autocomplete="off"' . ($isRequiredMessage ? ' required aria-required="true" aria-invalid="false"' : '') . '>' . esc_textarea($pForm->getFieldValue('message')) . '</textarea>'.$errorHtml.'</label>';
+			} else {
+				echo '<input type="hidden" name="message" value="' . esc_attr($pForm->getFieldValue('message')) . '">';
+			}
+			continue;
 		}
-	
+
 		$isHiddenField = $pForm->isHiddenField($input);
-		$label = esc_html($pForm->getFieldLabel($input)) . ' ' . wp_kses_post($addition);
+		$label = wp_kses_post($pForm->getFieldLabel($input)) . ' ' . wp_kses_post($addition);
 
 		if (\onOffice\WPlugin\Types\FieldTypes::FIELD_TYPE_SINGLESELECT== $pForm->getFieldType($input)) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- renderFormField returns escaped HTML
             echo !$isHiddenField ? '<div class="oo-single-select"><label for="'.esc_attr($input).'-ts-control"><span class="oo-label-text' . ($displayError && $isRequired ? ' displayerror' : '') . '">'.$label.'</span></label>' . renderFormField($input, $pForm).'</div>' : renderFormField($input, $pForm);
 		} else {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- renderFormField returns escaped HTML
-            echo !$isHiddenField ? '<label><span class="oo-label-text' . ($displayError && $isRequired ? ' displayerror' : '') . '">'.$label . renderFormField($input, $pForm).'</span></label>' : renderFormField($input, $pForm);
+			echo !$isHiddenField ? '<label><span class="oo-label-text' . ($displayError && $isRequired ? ' displayerror' : '') . '">'.$label . renderFormField($input, $pForm).'</span></label>' : renderFormField($input, $pForm);
 		}
 	}
 ?>

--- a/templates.dist/form/defaultform.php
+++ b/templates.dist/form/defaultform.php
@@ -96,7 +96,7 @@ if ($pForm->getFormStatus() === onOffice\WPlugin\FormPost::MESSAGE_SUCCESS) {
 			$errorHtml = renderErrorHtml($errorMessage, $isRequiredMessage);
 
 			if (!$isHiddenField) {
-				echo  '<label class="' . ($displayError && $isRequired ? ' displayerror' : '') . '">'.esc_html($pForm->getFieldLabel( 'message' ));
+				echo  '<label class="' . ($displayError && $isRequired ? ' displayerror' : '') . '">'.wp_kses_post($pForm->getFieldLabel( 'message' ));
 				echo  ' '.wp_kses_post($additionMessage);
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $errorHtml is already escaped from renderErrorHtml
 				echo  '<textarea name="message" data-rule="text" autocomplete="off"' . ($isRequiredMessage ? ' required aria-required="true" aria-invalid="false"' : '') . '>' . esc_textarea($pForm->getFieldValue('message')) . '</textarea>'.$errorHtml.'</label>';

--- a/templates.dist/form/defaultform.php
+++ b/templates.dist/form/defaultform.php
@@ -85,7 +85,7 @@ if ($pForm->getFormStatus() === onOffice\WPlugin\FormPost::MESSAGE_SUCCESS) {
 		if ( in_array( $input, array( 'gdprcheckbox' ) ) ) {
             // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- renderFormField returns escaped HTML
             echo '<label><span class="oo-label-text ' . ($displayError && $isRequired ? ' displayerror' : '') . '">';
-            echo esc_html($pForm->getFieldLabel( 'gdprcheckbox' )) .' '. wp_kses_post($addition).renderFormField( 'gdprcheckbox', $pForm ).'</span></label>';
+            echo wp_kses_post($pForm->getFieldLabel( 'gdprcheckbox' )) .' '. wp_kses_post($addition).renderFormField( 'gdprcheckbox', $pForm ).'</span></label>';
             continue;
         }
 		if ( in_array( $input, array( 'message' ) ) ) {

--- a/templates.dist/form/ownerform.php
+++ b/templates.dist/form/ownerform.php
@@ -67,20 +67,12 @@ if ($pForm->getFormStatus() === \onOffice\WPlugin\FormPost::MESSAGE_SUCCESS) {
 			$hiddenValues []= renderFormField($input, $pForm);
 			continue;
 		}
-		
-		switch ($input) {
-			case "ort": $fieldLabel = esc_html__('Property Location', 'onoffice-for-wp-websites'); break;
-			case "plz": $fieldLabel = esc_html__('Property ZIP Cod', 'onoffice-for-wp-websites'); break;
-			case "strasse": $fieldLabel = esc_html__('Property Street', 'onoffice-for-wp-websites'); break;
-			case "hausnummer": $fieldLabel = esc_html__('Property House Number', 'onoffice-for-wp-websites'); break;
-			default: $fieldLabel = $pForm->getFieldLabel($input);
-		}
 
 		$isRequired = $pForm->isRequiredField($input);
 		$addition   = $isRequired ? '<span class="oo-visually-hidden">'.esc_html__('Pflichtfeld', 'onoffice-for-wp-websites').'</span><span aria-hidden="true">*</span>' : '';
 		
 		$isHiddenField = $pForm->isHiddenField($input);
-		$label = esc_html($pForm->getFieldLabel($input)) . ' ' . wp_kses_post($addition);
+		$label = wp_kses_post($pForm->getFieldLabel($input)) . ' ' . wp_kses_post($addition);
 
 		if ((\onOffice\WPlugin\Types\FieldTypes::FIELD_TYPE_SINGLESELECT== $pForm->getFieldType($input))) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $label contains escaped HTML and renderFormField returns escaped HTML
@@ -100,7 +92,7 @@ if ($pForm->getFormStatus() === \onOffice\WPlugin\FormPost::MESSAGE_SUCCESS) {
 		if ( in_array( $input, array( 'gdprcheckbox' ) ) ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- renderFormField returns escaped HTML
             $line = '<label><span class="oo-label-text' . ($displayError && $isRequired ? ' displayerror' : '') . '">';
-			$line .= esc_html($pForm->getFieldLabel( 'gdprcheckbox' )) .' '. wp_kses_post($addition).renderFormField( 'gdprcheckbox', $pForm ).'</span></label>';
+			$line .= wp_kses_post($pForm->getFieldLabel( 'gdprcheckbox' )) .' '. wp_kses_post($addition).renderFormField( 'gdprcheckbox', $pForm ).'</span></label>';
 		}
 		if ( in_array( $input, array( 'message' )) ) {
 			$isRequiredMessage = $pForm->isRequiredField( 'message' );
@@ -110,7 +102,7 @@ if ($pForm->getFormStatus() === \onOffice\WPlugin\FormPost::MESSAGE_SUCCESS) {
 			$errorHtml = renderErrorHtml($errorMessage, $isRequiredMessage);
 			
 			if (!$isHiddenField) {
-				$line = '<label class="' . ($displayError && $isRequired ? ' displayerror' : '') . '">'.$pForm->getFieldLabel( 'message' );
+				$line = '<label class="' . ($displayError && $isRequired ? ' displayerror' : '') . '">'.wp_kses_post($pForm->getFieldLabel( 'message' ));
 				$line .= ' '.$additionMessage;
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $errorHtml is already escaped from renderErrorHtml
                 $line .= '<textarea name="message" autocomplete="off"' . ($isRequiredMessage ? ' required aria-required="true" aria-invalid="false"' : '') . '>' . esc_textarea($pForm->getFieldValue('message')) . '</textarea>'.$errorHtml.'</label>';

--- a/templates.dist/form/ownerform.php
+++ b/templates.dist/form/ownerform.php
@@ -108,7 +108,7 @@ if ($pForm->getFormStatus() === \onOffice\WPlugin\FormPost::MESSAGE_SUCCESS) {
                 $line .= '<textarea name="message" autocomplete="off"' . ($isRequiredMessage ? ' required aria-required="true" aria-invalid="false"' : '') . '>' . esc_textarea($pForm->getFieldValue('message')) . '</textarea>'.$errorHtml.'</label>';
 
 			} else {
-				$line = '<input type="hidden" name="message" value="' . $pForm->getFieldValue('message') . '">';
+				$line = '<input type="hidden" name="message" value="' . esc_attr($pForm->getFieldValue('message')) . '">';
 			}
 		}
 		if ($table == 'address') {

--- a/templates.dist/form/ownerleadgeneratorform.php
+++ b/templates.dist/form/ownerleadgeneratorform.php
@@ -72,7 +72,7 @@ if ($pForm->getFormStatus() === FormPost::MESSAGE_SUCCESS) {
 		$isRequired = $pForm->isRequiredField($input);
 		$addition   = $isRequired ? '<span class="oo-visually-hidden">'.esc_html__('Pflichtfeld', 'onoffice-for-wp-websites').'</span><span aria-hidden="true">*</span>' : '';
 		$isHiddenField = $pForm->isHiddenField($input);
-		$label = $fieldLabel.' '.wp_kses_post($addition);
+		$label = wp_kses_post($fieldLabel).' '.wp_kses_post($addition);
 
 		if (\onOffice\WPlugin\Types\FieldTypes::FIELD_TYPE_SINGLESELECT== $pForm->getFieldType($input)) {
 


### PR DESCRIPTION
In dem Label der Defaultform soll Markdown möglich sein, damit man u.A. einfach auf die Datenschutzbestimmungen verklinken kann:
<img width="645" height="39" alt="image" src="https://github.com/user-attachments/assets/be7f6ac5-3a55-4ea2-868c-007d963819cd" />
Das ist auch bereits ein implementiertes Feature, es wurde nur mir `esc_html` escaped statt mit `wp_kses` was dazu führte, dass auch die Tags vom Markdown escaped wurden.

Wenn du schauen willst, ob Wordpress diese Änderung so annimmt, dann am Besten das Plugin `Plugin Check (PCP)` installieren und damit unser Plugin einmal überprüfen.