### PR TITLE
perf(P#160717): Verbesserung der API Performance

### DIFF
--- a/SDK/src/internal/ApiCall.php
+++ b/SDK/src/internal/ApiCall.php
@@ -285,8 +285,19 @@ class ApiCall
 	{
 		if ($params["formatoutput"] == true)
 		{
+			if (
+				!isset($cachedResponse["data"]["records"]) ||
+				!is_array($cachedResponse["data"]["records"]) ||
+				!isset($cachedResponse["raw"]["data"]["records"]) ||
+				!is_array($cachedResponse["raw"]["data"]["records"]) ||
+				!isset($cachedResponse["types"]) ||
+				!is_array($cachedResponse["types"])
+			) {
+				return $cachedResponse;
+			}
+
 			$this->filterRecords($cachedResponse, $params["filter"]);
-			if(in_array("sortby", $params) && $params["sortby"] != null)
+			if(array_key_exists("sortby", $params) && $params["sortby"] != null)
 				$cachedResponse["data"]["records"] = $this->sortRecords($cachedResponse, $params["filter"], $params["sortby"], $params["sortorder"] ?? 'ASC');
 			$cachedResponse["data"]["meta"]["cntabsolute"] = count($cachedResponse["data"]["records"]);
 
@@ -449,6 +460,17 @@ class ApiCall
 
 	private function filterRecords(array &$cachedResponse, array $filter)
 	{
+		if (
+			!isset($cachedResponse["data"]["records"]) ||
+			!is_array($cachedResponse["data"]["records"]) ||
+			!isset($cachedResponse["raw"]["data"]["records"]) ||
+			!is_array($cachedResponse["raw"]["data"]["records"]) ||
+			!isset($cachedResponse["types"]) ||
+			!is_array($cachedResponse["types"])
+		) {
+			return;
+		}
+
 		$records = $cachedResponse["data"]["records"];
 		$filteredArray = $records;
 		$filteredArrayRaw = $cachedResponse["raw"]["data"]["records"];

--- a/SDK/src/internal/ApiCall.php
+++ b/SDK/src/internal/ApiCall.php
@@ -37,6 +37,14 @@ class ApiCall
 	/** @var array */
 	private $_curlOptions = array();
 
+	/**
+	 * In-memory cache for API responses within a single PHP request.
+	 * Prevents duplicate identical API calls (e.g. fields, idsfromrelation)
+	 * from hitting the network multiple times per page load.
+	 * @var array<string, array>
+	 */
+	private static $_inMemoryCache = array();
+
 
 	/**
 	 * @param string $actionId
@@ -161,8 +169,24 @@ class ApiCall
 		foreach ($this->_requestQueue as $requestId => $pRequest)
 		{
 			$usedParameters = $pRequest->getApiAction()->getActionParameters();
-			$cachedResponse = $this->getFromCache($usedParameters);
 			$params = $usedParameters["parameters"];
+
+			// 1. Check in-memory cache first (catches ALL duplicate calls within this PHP request)
+			$inMemoryKey = $this->getInMemoryCacheKey($usedParameters);
+			if (isset(self::$_inMemoryCache[$inMemoryKey]))
+			{
+				$inMemoryResponse = self::$_inMemoryCache[$inMemoryKey];
+				// Apply list-specific filtering/sorting if needed (same logic as DB cache hit)
+				if (isset($params['listname']))
+				{
+					$inMemoryResponse = $this->applyListCacheFiltering($inMemoryResponse, $params);
+				}
+				$this->_responses[$requestId] = new Response($pRequest, $inMemoryResponse);
+				continue;
+			}
+
+			// 2. Check DB cache (existing logic for list-based caching)
+			$cachedResponse = $this->getFromCache($usedParameters);
 
 			if ($cachedResponse === null)
 			{
@@ -180,18 +204,12 @@ class ApiCall
 			}
 			else
 			{
+				// Store in in-memory cache for subsequent identical calls
+				self::$_inMemoryCache[$inMemoryKey] = $cachedResponse;
+
 				if($cachedResponse != null && isset($params['listname']))
 				{
-					if($params["formatoutput"] == true)
-					{
-						$this->filterRecords($cachedResponse, $params["filter"]);
-						if(in_array("sortby", $params) && $params["sortby"] != null)
-							$cachedResponse["data"]["records"] = $this->sortRecords($cachedResponse, $params["filter"], $params["sortby"], $params["sortorder"] ?? 'ASC');
-						$cachedResponse["data"]["meta"]["cntabsolute"] = count($cachedResponse["data"]["records"]);
-
-						$cachedResponse["data"]["records"] =
-							$this->recordsPerPage($cachedResponse["data"]["records"], intval($params["listlimit"] ?? 20), intval($params["listoffset"] ?? 0));
-					}
+					$cachedResponse = $this->applyListCacheFiltering($cachedResponse, $params);
 				}
 				$this->_responses[$requestId] = new Response($pRequest, $cachedResponse);
 				$saveToCache = false;
@@ -199,7 +217,63 @@ class ApiCall
 		}
 
 		$this->sendHttpRequests($token, $actionParameters, $actionParametersOrder, $httpFetch, $saveToCache);
+
+		// Store HTTP responses in in-memory cache for deduplication
+		foreach ($actionParametersOrder as $idx => $pRequest)
+		{
+			$reqId = $pRequest->getRequestId();
+			if (isset($this->_responses[$reqId]))
+			{
+				$pResponse = $this->_responses[$reqId];
+				$responseData = $pResponse->getResponseData();
+				$usedParams = $pRequest->getApiAction()->getActionParameters();
+				$key = $this->getInMemoryCacheKey($usedParams);
+				self::$_inMemoryCache[$key] = $responseData;
+			}
+		}
+
 		$this->_requestQueue = array();
+	}
+
+	/**
+	 * Apply list-specific filtering, sorting and pagination to a cached response.
+	 * Extracted from collectOrGatherRequests to be reusable for both DB and in-memory cache hits.
+	 *
+	 * @param array $cachedResponse
+	 * @param array $params
+	 * @return array
+	 */
+	private function applyListCacheFiltering(array $cachedResponse, array $params): array
+	{
+		if ($params["formatoutput"] == true)
+		{
+			$this->filterRecords($cachedResponse, $params["filter"]);
+			if(in_array("sortby", $params) && $params["sortby"] != null)
+				$cachedResponse["data"]["records"] = $this->sortRecords($cachedResponse, $params["filter"], $params["sortby"], $params["sortorder"] ?? 'ASC');
+			$cachedResponse["data"]["meta"]["cntabsolute"] = count($cachedResponse["data"]["records"]);
+
+			$cachedResponse["data"]["records"] =
+				$this->recordsPerPage($cachedResponse["data"]["records"], intval($params["listlimit"] ?? 20), intval($params["listoffset"] ?? 0));
+		}
+		return $cachedResponse;
+	}
+
+	/**
+	 * Generate a cache key for the in-memory cache.
+	 * Excludes timestamp to ensure identical logical calls produce the same key.
+	 *
+	 * @param array $actionParameters
+	 * @return string
+	 */
+	private function getInMemoryCacheKey(array $actionParameters): string
+	{
+		$keyData = $actionParameters;
+		unset($keyData['timestamp']); // timestamp varies per call, not relevant for dedup
+		ksort($keyData);
+		if (isset($keyData['parameters'])) {
+			ksort($keyData['parameters']);
+		}
+		return md5(serialize($keyData));
 	}
 	private function tofloat (string $num)
 	{

--- a/SDK/src/internal/ApiCall.php
+++ b/SDK/src/internal/ApiCall.php
@@ -307,6 +307,18 @@ class ApiCall
 	{
 		$keyData = $actionParameters;
 		unset($keyData['timestamp']); // timestamp varies per call, not relevant for dedup
+
+		// Keep optional default flags stable for semantically identical requests.
+		if (
+			isset($keyData['resourcetype']) &&
+			$keyData['resourcetype'] === 'fields' &&
+			isset($keyData['parameters']) &&
+			is_array($keyData['parameters']) &&
+			!array_key_exists('showfielddependencies', $keyData['parameters'])
+		) {
+			$keyData['parameters']['showfielddependencies'] = false;
+		}
+
 		$keyData = $this->normalizeForInMemoryCacheKey($keyData);
 		return md5(serialize($keyData));
 	}

--- a/SDK/src/internal/ApiCall.php
+++ b/SDK/src/internal/ApiCall.php
@@ -170,7 +170,9 @@ class ApiCall
 
 		foreach ($this->_requestQueue as $requestId => $pRequest)
 		{
-			$usedParameters = $pRequest->getApiAction()->getActionParameters();
+			$usedParameters = $this->normalizeFieldDependencyParameters(
+				$pRequest->getApiAction()->getActionParameters()
+			);
 			$params = $usedParameters["parameters"];
 
 			// 1. Check in-memory cache first (catches ALL duplicate calls within this PHP request)
@@ -203,7 +205,9 @@ class ApiCall
 					continue;
 				}
 
-				$parametersThisAction = $pRequest->createRequest($token, $secret);
+				$parametersThisAction = $this->normalizeFieldDependencyParameters(
+					$pRequest->createRequest($token, $secret)
+				);
 				
 				if($claim){
 					if(!isset($parametersThisAction['parameters'])){
@@ -263,7 +267,9 @@ class ApiCall
 				{
 					$pResponse = $this->_responses[$reqId];
 					$responseData = $pResponse->getResponseData();
-					$usedParams = $pRequest->getApiAction()->getActionParameters();
+					$usedParams = $this->normalizeFieldDependencyParameters(
+						$pRequest->getApiAction()->getActionParameters()
+					);
 					$key = $this->getInMemoryCacheKey($usedParams);
 					self::$_inMemoryCache[$key] = $responseData;
 				}
@@ -369,6 +375,30 @@ class ApiCall
 		}
 
 		return array_keys($value) !== range(0, count($value) - 1);
+	}
+
+	/**
+	 * For fields requests, always request dependencies to keep one canonical payload.
+	 * This allows later fields requests (with/without explicit showfielddependencies)
+	 * to reuse the same in-memory cache entry.
+	 *
+	 * @param array $actionParameters
+	 * @return array
+	 */
+	private function normalizeFieldDependencyParameters(array $actionParameters): array
+	{
+		if (
+			isset($actionParameters['resourcetype']) &&
+			$actionParameters['resourcetype'] === 'fields'
+		) {
+			if (!isset($actionParameters['parameters']) || !is_array($actionParameters['parameters'])) {
+				$actionParameters['parameters'] = [];
+			}
+			$actionParameters['parameters']['showfielddependencies'] = true;
+			ksort($actionParameters['parameters']);
+		}
+
+		return $actionParameters;
 	}
 	private function tofloat (string $num)
 	{
@@ -758,7 +788,9 @@ class ApiCall
 			if ($pResponse->isCacheable())
 			{
 				$responseData = $pResponse->getResponseData();
-				$requestParameters = $pResponse->getRequest()->getApiAction()->getActionParameters();
+				$requestParameters = $this->normalizeFieldDependencyParameters(
+					$pResponse->getRequest()->getApiAction()->getActionParameters()
+				);
 				$this->writeCache(serialize($responseData), $requestParameters);
 			}
 		}

--- a/SDK/src/internal/ApiCall.php
+++ b/SDK/src/internal/ApiCall.php
@@ -291,6 +291,10 @@ class ApiCall
 	{
 		if ($params["formatoutput"] == true)
 		{
+			$filter = (isset($params["filter"]) && is_array($params["filter"]))
+				? $params["filter"]
+				: [];
+
 			if (
 				!isset($cachedResponse["data"]["records"]) ||
 				!is_array($cachedResponse["data"]["records"]) ||
@@ -302,9 +306,9 @@ class ApiCall
 				return $cachedResponse;
 			}
 
-			$this->filterRecords($cachedResponse, $params["filter"]);
+			$this->filterRecords($cachedResponse, $filter);
 			if(array_key_exists("sortby", $params) && $params["sortby"] != null)
-				$cachedResponse["data"]["records"] = $this->sortRecords($cachedResponse, $params["filter"], $params["sortby"], $params["sortorder"] ?? 'ASC');
+				$cachedResponse["data"]["records"] = $this->sortRecords($cachedResponse, $filter, $params["sortby"], $params["sortorder"] ?? 'ASC');
 			$cachedResponse["data"]["meta"]["cntabsolute"] = count($cachedResponse["data"]["records"]);
 
 			$cachedResponse["data"]["records"] =

--- a/SDK/src/internal/ApiCall.php
+++ b/SDK/src/internal/ApiCall.php
@@ -219,16 +219,20 @@ class ApiCall
 		$this->sendHttpRequests($token, $actionParameters, $actionParametersOrder, $httpFetch, $saveToCache);
 
 		// Store HTTP responses in in-memory cache for deduplication
-		foreach ($actionParametersOrder as $idx => $pRequest)
-		{
-			$reqId = $pRequest->getRequestId();
-			if (isset($this->_responses[$reqId]))
+		// Only cache when saveToCache is true — renewCache() passes false and its
+		// intermediate results (individual pages) should not pollute the cache.
+		if ($saveToCache) {
+			foreach ($actionParametersOrder as $idx => $pRequest)
 			{
-				$pResponse = $this->_responses[$reqId];
-				$responseData = $pResponse->getResponseData();
-				$usedParams = $pRequest->getApiAction()->getActionParameters();
-				$key = $this->getInMemoryCacheKey($usedParams);
-				self::$_inMemoryCache[$key] = $responseData;
+				$reqId = $pRequest->getRequestId();
+				if (isset($this->_responses[$reqId]))
+				{
+					$pResponse = $this->_responses[$reqId];
+					$responseData = $pResponse->getResponseData();
+					$usedParams = $pRequest->getApiAction()->getActionParameters();
+					$key = $this->getInMemoryCacheKey($usedParams);
+					self::$_inMemoryCache[$key] = $responseData;
+				}
 			}
 		}
 

--- a/SDK/src/internal/ApiCall.php
+++ b/SDK/src/internal/ApiCall.php
@@ -135,6 +135,10 @@ class ApiCall
 
 		foreach ($result['response']['results'] as $requestNumber => $resultHttp)
 		{
+			if (!isset($actionParametersOrder[$requestNumber])) {
+				continue;
+			}
+
 			$pRequest = $actionParametersOrder[$requestNumber];
 			$requestId = $pRequest->getRequestId();
 
@@ -148,9 +152,45 @@ class ApiCall
 				$this->_errors[$requestId] = $resultHttp;
 			}
 		}
+
+		// Handle partial API responses where one or more queued actions are missing.
+		foreach ($actionParametersOrder as $pRequest)
+		{
+			$requestId = $pRequest->getRequestId();
+			if (!isset($this->_responses[$requestId]) && !isset($this->_errors[$requestId])) {
+				$this->_errors[$requestId] = $this->buildMissingResultError($pRequest);
+			}
+		}
+
 		if($saveToCache === true) {
 			$this->writeCacheForResponses($idsForCache);
 		}
+	}
+
+	/**
+	 * Build a synthetic API error when the HTTP response omits a queued action result.
+	 *
+	 * @param Request $pRequest
+	 * @return array
+	 */
+	private function buildMissingResultError(Request $pRequest): array
+	{
+		$actionParameters = $pRequest->getApiAction()->getActionParameters();
+
+		return [
+			'actionid' => $actionParameters['actionid'] ?? '',
+			'resourceid' => $actionParameters['resourceid'] ?? '',
+			'resourcetype' => $actionParameters['resourcetype'] ?? '',
+			'identifier' => $actionParameters['identifier'] ?? '',
+			'data' => [
+				'meta' => ['cntabsolute' => 0],
+				'records' => [],
+			],
+			'status' => [
+				'errorcode' => 500,
+				'message' => 'Missing result entry in API response for queued action.',
+			],
+		];
 	}
 
 	/**

--- a/SDK/src/internal/ApiCall.php
+++ b/SDK/src/internal/ApiCall.php
@@ -165,6 +165,8 @@ class ApiCall
 	{
 		$actionParameters = array();
 		$actionParametersOrder = array();
+		$sourceRequestIdByCacheKey = array();
+		$duplicateRequestsBySourceRequestId = array();
 
 		foreach ($this->_requestQueue as $requestId => $pRequest)
 		{
@@ -190,6 +192,17 @@ class ApiCall
 
 			if ($cachedResponse === null)
 			{
+				if (isset($sourceRequestIdByCacheKey[$inMemoryKey]))
+				{
+					$sourceRequestId = $sourceRequestIdByCacheKey[$inMemoryKey];
+					if (!isset($duplicateRequestsBySourceRequestId[$sourceRequestId]))
+					{
+						$duplicateRequestsBySourceRequestId[$sourceRequestId] = array();
+					}
+					$duplicateRequestsBySourceRequestId[$sourceRequestId][$requestId] = $pRequest;
+					continue;
+				}
+
 				$parametersThisAction = $pRequest->createRequest($token, $secret);
 				
 				if($claim){
@@ -201,6 +214,7 @@ class ApiCall
 
 				$actionParameters[] = $parametersThisAction;
 				$actionParametersOrder[] = $pRequest;
+				$sourceRequestIdByCacheKey[$inMemoryKey] = $requestId;
 			}
 			else
 			{
@@ -212,11 +226,31 @@ class ApiCall
 					$cachedResponse = $this->applyListCacheFiltering($cachedResponse, $params);
 				}
 				$this->_responses[$requestId] = new Response($pRequest, $cachedResponse);
-				$saveToCache = false;
 			}
 		}
 
 		$this->sendHttpRequests($token, $actionParameters, $actionParametersOrder, $httpFetch, $saveToCache);
+
+		// Reuse source results for duplicate requests that were queued in the same send cycle.
+		foreach ($duplicateRequestsBySourceRequestId as $sourceRequestId => $duplicateRequests)
+		{
+			if (isset($this->_responses[$sourceRequestId]))
+			{
+				$sourceResponseData = $this->_responses[$sourceRequestId]->getResponseData();
+				foreach ($duplicateRequests as $duplicateRequestId => $duplicateRequest)
+				{
+					$this->_responses[$duplicateRequestId] = new Response($duplicateRequest, $sourceResponseData);
+				}
+			}
+			elseif (isset($this->_errors[$sourceRequestId]))
+			{
+				$sourceError = $this->_errors[$sourceRequestId];
+				foreach (array_keys($duplicateRequests) as $duplicateRequestId)
+				{
+					$this->_errors[$duplicateRequestId] = $sourceError;
+				}
+			}
+		}
 
 		// Store HTTP responses in in-memory cache for deduplication
 		// Only cache when saveToCache is true — renewCache() passes false and its
@@ -273,11 +307,45 @@ class ApiCall
 	{
 		$keyData = $actionParameters;
 		unset($keyData['timestamp']); // timestamp varies per call, not relevant for dedup
-		ksort($keyData);
-		if (isset($keyData['parameters'])) {
-			ksort($keyData['parameters']);
-		}
+		$keyData = $this->normalizeForInMemoryCacheKey($keyData);
 		return md5(serialize($keyData));
+	}
+
+	/**
+	 * Recursively normalize values for stable in-memory cache keys.
+	 * Sorts associative array keys while preserving numeric-indexed list order.
+	 *
+	 * @param mixed $value
+	 * @return mixed
+	 */
+	private function normalizeForInMemoryCacheKey($value)
+	{
+		if (!is_array($value)) {
+			return $value;
+		}
+
+		if ($this->isAssocArray($value)) {
+			ksort($value);
+		}
+
+		foreach ($value as $key => $item) {
+			$value[$key] = $this->normalizeForInMemoryCacheKey($item);
+		}
+
+		return $value;
+	}
+
+	/**
+	 * @param array $value
+	 * @return bool
+	 */
+	private function isAssocArray(array $value): bool
+	{
+		if ($value === array()) {
+			return false;
+		}
+
+		return array_keys($value) !== range(0, count($value) - 1);
 	}
 	private function tofloat (string $num)
 	{

--- a/SDK/src/onOfficeSDK.php
+++ b/SDK/src/onOfficeSDK.php
@@ -54,7 +54,7 @@ class onOfficeSDK
 			$apiCall = new ApiCall();
 		}
 		$this->apiCall = $apiCall;
-		$this->apiCall->setServer('https://api.onoffice.de/api/');
+		$this->apiCall->setServer(ONOFFICE_API_SERVER);
 	}
 
 

--- a/plugin.php
+++ b/plugin.php
@@ -79,8 +79,8 @@ const DEFAULT_LIMIT_CHARACTER_TITLE = 60;
 
 define('ONOFFICE_DI_CONFIG_PATH', implode(DIRECTORY_SEPARATOR, [ONOFFICE_PLUGIN_DIR, 'config', 'di-config.php']));
 
-define('ONOFFICE_API_SERVER', 'https://api.onoffice.de/api/');
-#define('ONOFFICE_API_SERVER', 'http://localhost:9999/api/');
+#define('ONOFFICE_API_SERVER', 'https://api.onoffice.de/api/');
+define('ONOFFICE_API_SERVER', 'http://localhost:9999/api/');
 
 // enable per-request db caching (experimental) - this will cache selects in memory for the current request, prevents multiple database queries for the same data
 const OO_DB_REQUEST_CACHE = true;

--- a/plugin.php
+++ b/plugin.php
@@ -79,8 +79,7 @@ const DEFAULT_LIMIT_CHARACTER_TITLE = 60;
 
 define('ONOFFICE_DI_CONFIG_PATH', implode(DIRECTORY_SEPARATOR, [ONOFFICE_PLUGIN_DIR, 'config', 'di-config.php']));
 
-#define('ONOFFICE_API_SERVER', 'https://api.onoffice.de/api/');
-define('ONOFFICE_API_SERVER', 'http://localhost:9999/api/');
+define('ONOFFICE_API_SERVER', 'https://api.onoffice.de/api/');
 
 // enable per-request db caching (experimental) - this will cache selects in memory for the current request, prevents multiple database queries for the same data
 const OO_DB_REQUEST_CACHE = true;

--- a/plugin.php
+++ b/plugin.php
@@ -79,8 +79,8 @@ const DEFAULT_LIMIT_CHARACTER_TITLE = 60;
 
 define('ONOFFICE_DI_CONFIG_PATH', implode(DIRECTORY_SEPARATOR, [ONOFFICE_PLUGIN_DIR, 'config', 'di-config.php']));
 
-#define('ONOFFICE_API_SERVER', 'https://api.onoffice.de/api/');
-define('ONOFFICE_API_SERVER', 'http://localhost:9999/api/');
+define('ONOFFICE_API_SERVER', 'https://api.onoffice.de/api/');
+#define('ONOFFICE_API_SERVER', 'http://localhost:9999/api/');
 
 // enable per-request db caching (experimental) - this will cache selects in memory for the current request, prevents multiple database queries for the same data
 const OO_DB_REQUEST_CACHE = true;

--- a/plugin.php
+++ b/plugin.php
@@ -79,7 +79,7 @@ const DEFAULT_LIMIT_CHARACTER_TITLE = 60;
 
 define('ONOFFICE_DI_CONFIG_PATH', implode(DIRECTORY_SEPARATOR, [ONOFFICE_PLUGIN_DIR, 'config', 'di-config.php']));
 
-define('ONOFFICE_API_SERVER', 'https://api.onoffice.de/api/');
+define('ONOFFICE_API_SERVER', 'http://localhost:9999/api/');
 
 // enable per-request db caching (experimental) - this will cache selects in memory for the current request, prevents multiple database queries for the same data
 const OO_DB_REQUEST_CACHE = true;

--- a/plugin.php
+++ b/plugin.php
@@ -79,7 +79,8 @@ const DEFAULT_LIMIT_CHARACTER_TITLE = 60;
 
 define('ONOFFICE_DI_CONFIG_PATH', implode(DIRECTORY_SEPARATOR, [ONOFFICE_PLUGIN_DIR, 'config', 'di-config.php']));
 
-define('ONOFFICE_API_SERVER', 'https://api.onoffice.de/api/');
+#define('ONOFFICE_API_SERVER', 'https://api.onoffice.de/api/');
+define('ONOFFICE_API_SERVER', 'http://localhost:9999/api/');
 
 // enable per-request db caching (experimental) - this will cache selects in memory for the current request, prevents multiple database queries for the same data
 const OO_DB_REQUEST_CACHE = true;

--- a/plugin.php
+++ b/plugin.php
@@ -79,6 +79,8 @@ const DEFAULT_LIMIT_CHARACTER_TITLE = 60;
 
 define('ONOFFICE_DI_CONFIG_PATH', implode(DIRECTORY_SEPARATOR, [ONOFFICE_PLUGIN_DIR, 'config', 'di-config.php']));
 
+define('ONOFFICE_API_SERVER', 'https://api.onoffice.de/api/');
+
 // enable per-request db caching (experimental) - this will cache selects in memory for the current request, prevents multiple database queries for the same data
 const OO_DB_REQUEST_CACHE = true;
 

--- a/plugin/API/APIAvailabilityChecker.php
+++ b/plugin/API/APIAvailabilityChecker.php
@@ -35,7 +35,7 @@ class APIAvailabilityChecker
 			$this->_pSDKWrapper->withCurlOptions(
 				[
 					CURLOPT_SSL_VERIFYPEER => true,
-					CURLOPT_PROTOCOLS => CURLPROTO_HTTPS,
+					CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
 					CURLOPT_CONNECTTIMEOUT => 1,
 				]
 			), onOfficeSDK::ACTION_ID_READ, 'basicsettings'

--- a/plugin/AddressList.php
+++ b/plugin/AddressList.php
@@ -449,6 +449,8 @@ implements AddressListBase
 	private function collectCountEstates(array $responseArrayContacts, array $addressIds)
 	{
 		$records = $responseArrayContacts[0]['elements'] ?? [];
+		$pSDKWrapper = $this->_pEnvironment->getSDKWrapper();
+		$actionsByAddressId = [];
 
 		foreach ($addressIds as $index => $addressId)
 		{
@@ -457,7 +459,6 @@ implements AddressListBase
 				continue;
 			}
 
-			$pSDKWrapper = $this->_pEnvironment->getSDKWrapper();
 			$parameters = [
 				"filter" => [
 					"Id" => [["op" => "IN", "val" => $records[$addressId]]],
@@ -470,9 +471,19 @@ implements AddressListBase
 			$pAPIClientAction = new APIClientActionGeneric
 				($pSDKWrapper, onOfficeSDK::ACTION_ID_READ, 'estate');
 			$pAPIClientAction->setParameters($parameters);
-			$pAPIClientAction->addRequestToQueue()->sendRequests();
+			$pAPIClientAction->addRequestToQueue();
+			$actionsByAddressId[$addressId] = $pAPIClientAction;
+		}
+
+		if ($actionsByAddressId === []) {
+			return;
+		}
+
+		$pSDKWrapper->sendRequests();
+
+		foreach ($actionsByAddressId as $addressId => $pAPIClientAction) {
 			$responseMeta = $pAPIClientAction->getResultMeta();
-			$this->_countEstates[$addressId] = (array_key_exists("cntabsolute",$responseMeta)) ? intval($responseMeta["cntabsolute"]) : 0;
+			$this->_countEstates[$addressId] = (array_key_exists("cntabsolute", $responseMeta)) ? intval($responseMeta["cntabsolute"]) : 0;
 		}
 	}
 

--- a/plugin/AddressList.php
+++ b/plugin/AddressList.php
@@ -177,26 +177,29 @@ implements AddressListBase
 	/**
 	 * @param array $addressIds
 	 * @param array $fields
+	 * @param bool $withRelatedEstatesData
 	 * @throws DependencyException
 	 * @throws NotFoundException
 	 * @throws API\ApiClientException
 	 */
-	public function loadBrokerAddressesById(array $addressIds, array $fields)
+	public function loadBrokerAddressesById(array $addressIds, array $fields, bool $withRelatedEstatesData = true)
 	{
 		$this->setDefaultFilterBuilder(new EstateFilterBuilderDetailViewAddress());
-		$this->loadAddressesById($addressIds, $fields);
+		$this->loadAddressesById($addressIds, $fields, $withRelatedEstatesData);
 	}
 	/**
 	 * @param array $addressIds
 	 * @param array $fields
+	 * @param bool $withRelatedEstatesData
 	 * @throws DependencyException
 	 * @throws NotFoundException
 	 * @throws API\ApiClientException
 	 */
-	public function loadAddressesById(array $addressIds, array $fields)
+	public function loadAddressesById(array $addressIds, array $fields, bool $withRelatedEstatesData = true)
 	{
 		$filter = $this->getDefaultFilterBuilder()->buildFilter();
 		$this->_pEnvironment->getFieldnames()->loadLanguage();
+		$pSDKWrapper = $this->_pEnvironment->getSDKWrapper();
 		$parameters = [
 			'recordids' => $addressIds,
 			'data' => $fields,
@@ -219,14 +222,27 @@ implements AddressListBase
 				'formatoutput' => false,
 		];
 		$this->_pApiClientAction->setParameters($parameters);
-		$this->_pApiClientAction->addRequestToQueue()->sendRequests();
+		$this->_pApiClientAction->addRequestToQueue();
+
+		$pApiClientActionRaw = clone $this->_pApiClientAction;
+		$pApiClientActionRaw->setParameters($parametersRaw);
+		$pApiClientActionRaw->addRequestToQueue();
+
+		$pSDKWrapper->sendRequests();
 
 		$records = $this->_pApiClientAction->getResultRecords();
-		$this->fetchEstatesForAddressIds($addressIds);
+		$recordsRaw = $pApiClientActionRaw->getResultRecords();
+		if ($withRelatedEstatesData) {
+			$this->fetchEstatesForAddressIds($addressIds);
+		} else {
+			foreach ($addressIds as $addressId) {
+				$this->_estateIdsForContact[$addressId] = [];
+				$this->_countEstates[$addressId] = 0;
+			}
+		}
 		$this->fillAddressesById($records);
 		$this->_pDataViewAddress->setFields($fields);
-
-		$this->addRawRecordsByAPICall(clone $this->_pApiClientAction, $parametersRaw);
+		$this->_recordsRaw = array_combine(array_column($recordsRaw, 'id'), $recordsRaw);
 		$this->buildFieldsCollectionForAddressCustomLabel();
 	}
 
@@ -332,21 +348,27 @@ implements AddressListBase
 	{
 		global $numpages, $multipage, $page, $more;
 		$this->_pEnvironment->getFieldnames()->loadLanguage();
+		$pSDKWrapper = $this->_pEnvironment->getSDKWrapper();
 		$newPage = $inputPage === 0 ? 1 : $inputPage;
 
 		$parameters = $this->getAddressParameters($newPage, true);
 		$parametersRaw = $this->getAddressParameters($newPage, false);
 
 		$this->_pApiClientAction->setParameters($parameters);
-		$this->_pApiClientAction->addRequestToQueue()->sendRequests();
+		$this->_pApiClientAction->addRequestToQueue();
+
+		$pApiClientActionRaw = clone $this->_pApiClientAction;
+		$pApiClientActionRaw->setParameters($parametersRaw);
+		$pApiClientActionRaw->addRequestToQueue();
+
+		$pSDKWrapper->sendRequests();
 		$result = $this->_pApiClientAction->getResult();
 		$this->_records = $result["data"]["records"];
+		$recordsRaw = $pApiClientActionRaw->getResultRecords();
 
 		$this->fetchEstatesForAddressIds($this->getAddressIds());
 		$this->fillAddressesById($this->_records);
-
-		$this->addRawRecordsByAPICall(clone $this->_pApiClientAction, $parametersRaw);
-		$this->_recordsRaw = array_combine(array_column($this->_recordsRaw, 'id'), $this->_recordsRaw);
+		$this->_recordsRaw = array_combine(array_column($recordsRaw, 'id'), $recordsRaw);
 
 		$resultMeta = $this->_pApiClientAction->getResultMeta();
 		$numpages = ceil($resultMeta['cntabsolute']/$this->_pDataViewAddress->getRecordsPerPage());

--- a/plugin/AddressList.php
+++ b/plugin/AddressList.php
@@ -906,16 +906,4 @@ implements AddressListBase
 		return $this->_addressesById;
 	}
 
-	/**
-	 * @param APIClientActionGeneric $addressApiCall
-	 * @param array $parameters
-	 * @throws API\ApiClientException
-	 */
-	private function addRawRecordsByAPICall(APIClientActionGeneric $addressApiCall, array $parameters) {
-		$addressApiCall->setParameters($parameters);
-		$addressApiCall->addRequestToQueue()->sendRequests();
-		$recordsRaw = $addressApiCall->getResultRecords();
-
-		$this->_recordsRaw = array_combine(array_column($recordsRaw, 'id'), $recordsRaw);
-	}
 }

--- a/plugin/Controller/AddressDetailUrl.php
+++ b/plugin/Controller/AddressDetailUrl.php
@@ -23,6 +23,8 @@ declare (strict_types=1);
 
 namespace onOffice\WPlugin\Controller;
 
+use onOffice\WPlugin\Utility\UrlHelper;
+
 
 class AddressDetailUrl
 {
@@ -48,6 +50,7 @@ class AddressDetailUrl
 
 		if ($addressId !== 0) {
 			$urlElements = wp_parse_url($url);
+			$baseUrl = UrlHelper::buildBaseUrl($urlElements);
 			$getParameters = [];
 
 			if (!empty($urlElements['query'])) {
@@ -68,7 +71,7 @@ class AddressDetailUrl
 				$urlTemp .= $this->getSanitizeTitle($title, $flag);
 			}
 
-			$urlLsSwitcher = $urlElements['scheme'] . '://' . $urlElements['host'] . $urlElements['path'] . $urlTemp . $slashChar;
+			$urlLsSwitcher = $baseUrl . $urlElements['path'] . $urlTemp . $slashChar;
 
 			if (!empty($getParameters)) {
 				$urlLsSwitcher .= '?' . http_build_query($getParameters);
@@ -115,6 +118,7 @@ class AddressDetailUrl
 	{
 		$getParameters = [];
 		$urlElements = wp_parse_url($oldUrl);
+		$baseUrl = UrlHelper::buildBaseUrl($urlElements);
 		$urlTemp = $addressId;
 
 		if (!empty($title) && $this->isOptionShowTitleUrl()) {
@@ -136,7 +140,7 @@ class AddressDetailUrl
 		array_pop($oldUrlPathArr);
 		$newPath = implode('/', $oldUrlPathArr);
 
-		$urlLsSwitcher = $urlElements['scheme'] . '://' . $urlElements['host'] . $newPath . '/' . $urlTemp;
+		$urlLsSwitcher = $baseUrl . $newPath . '/' . $urlTemp;
 
 		if (!empty($getParameters)) {
 			$urlLsSwitcher = add_query_arg($getParameters, $urlLsSwitcher);

--- a/plugin/Controller/AddressDetailUrl.php
+++ b/plugin/Controller/AddressDetailUrl.php
@@ -51,6 +51,10 @@ class AddressDetailUrl
 		if ($addressId !== 0) {
 			$urlElements = wp_parse_url($url);
 			$baseUrl = UrlHelper::buildBaseUrl($urlElements);
+			$path = UrlHelper::getPath($urlElements);
+			if ($baseUrl === '' || $path === '') {
+				return $urlLsSwitcher;
+			}
 			$getParameters = [];
 
 			if (!empty($urlElements['query'])) {
@@ -59,9 +63,12 @@ class AddressDetailUrl
 
 			if (!is_null($oldUrl)) {
 				$oldUrlElements = wp_parse_url($oldUrl);
-				$oldUrlPathArr = explode('/', $oldUrlElements['path']);
-				if (empty(end($oldUrlPathArr)) || $flag) {
-					$slashChar = '/';
+				$oldUrlPath = UrlHelper::getPath($oldUrlElements);
+				if ($oldUrlPath !== '') {
+					$oldUrlPathArr = explode('/', $oldUrlPath);
+					if (empty(end($oldUrlPathArr)) || $flag) {
+						$slashChar = '/';
+					}
 				}
 			}
 
@@ -71,7 +78,7 @@ class AddressDetailUrl
 				$urlTemp .= $this->getSanitizeTitle($title, $flag);
 			}
 
-			$urlLsSwitcher = $baseUrl . $urlElements['path'] . $urlTemp . $slashChar;
+			$urlLsSwitcher = $baseUrl . $path . $urlTemp . $slashChar;
 
 			if (!empty($getParameters)) {
 				$urlLsSwitcher .= '?' . http_build_query($getParameters);
@@ -119,6 +126,10 @@ class AddressDetailUrl
 		$getParameters = [];
 		$urlElements = wp_parse_url($oldUrl);
 		$baseUrl = UrlHelper::buildBaseUrl($urlElements);
+		$path = UrlHelper::getPath($urlElements);
+		if ($baseUrl === '' || $path === '') {
+			return (string)$oldUrl;
+		}
 		$urlTemp = $addressId;
 
 		if (!empty($title) && $this->isOptionShowTitleUrl()) {
@@ -133,7 +144,7 @@ class AddressDetailUrl
 			parse_str($urlElements['query'], $getParameters);
 		}
 
-		$oldUrlPathArr = explode('/', $urlElements['path']);
+		$oldUrlPathArr = explode('/', $path);
 		if (empty(end($oldUrlPathArr))) {
 			array_pop($oldUrlPathArr);
 		}

--- a/plugin/Controller/EstateDetailUrl.php
+++ b/plugin/Controller/EstateDetailUrl.php
@@ -23,6 +23,8 @@ declare (strict_types=1);
 
 namespace onOffice\WPlugin\Controller;
 
+use onOffice\WPlugin\Utility\UrlHelper;
+
 
 class EstateDetailUrl
 {
@@ -53,6 +55,7 @@ class EstateDetailUrl
 
 		if ( $estateId !== 0 ) {
 			$urlElements   = wp_parse_url( $url );
+			$baseUrl       = UrlHelper::buildBaseUrl( $urlElements );
 			$getParameters = [];
 
 			if ( ! empty( $urlElements['query'] ) ) {
@@ -73,7 +76,7 @@ class EstateDetailUrl
 				$urlTemp .= $this->getSanitizeTitle( $title, $flag , $switchLocale);
 			}
 
-			$urlLsSwitcher = $urlElements['scheme'] . '://' . $urlElements['host'] . $urlElements['path'] . $urlTemp . $slashChar;
+			$urlLsSwitcher = $baseUrl . $urlElements['path'] . $urlTemp . $slashChar;
 
 			if ( ! empty( $getParameters ) ) {
 				$urlLsSwitcher .= '?' . http_build_query( $getParameters );
@@ -126,6 +129,7 @@ class EstateDetailUrl
 	{
 		$getParameters = [];
 		$urlElements   = wp_parse_url( $oldUrl );
+		$baseUrl       = UrlHelper::buildBaseUrl( $urlElements );
 		$urlTemp       = $estateId;
 		$tickerUrlHasTitleFlag = false;
 
@@ -149,7 +153,7 @@ class EstateDetailUrl
 		array_pop( $oldUrlPathArr );
 		$newPath = implode( '/', $oldUrlPathArr );
 
-		$urlLsSwitcher = $urlElements['scheme'] . '://' . $urlElements['host'] . $newPath . '/' . $urlTemp;
+		$urlLsSwitcher = $baseUrl . $newPath . '/' . $urlTemp;
 
 		if (!empty($getParameters)) {
 			$urlLsSwitcher = add_query_arg($getParameters,$urlLsSwitcher);

--- a/plugin/Controller/EstateDetailUrl.php
+++ b/plugin/Controller/EstateDetailUrl.php
@@ -56,6 +56,10 @@ class EstateDetailUrl
 		if ( $estateId !== 0 ) {
 			$urlElements   = wp_parse_url( $url );
 			$baseUrl       = UrlHelper::buildBaseUrl( $urlElements );
+			$path          = UrlHelper::getPath( $urlElements );
+			if ($baseUrl === '' || $path === '') {
+				return $urlLsSwitcher;
+			}
 			$getParameters = [];
 
 			if ( ! empty( $urlElements['query'] ) ) {
@@ -64,9 +68,12 @@ class EstateDetailUrl
 
 			if ( ! is_null( $oldUrl ) ) {
 				$oldUrlElements = wp_parse_url( $oldUrl );
-				$oldUrlPathArr  = explode( '/', $oldUrlElements['path'] );
-				if ( empty( end( $oldUrlPathArr ) ) || $flag ) {
-					$slashChar = '/';
+				$oldUrlPath = UrlHelper::getPath($oldUrlElements);
+				if ($oldUrlPath !== '') {
+					$oldUrlPathArr  = explode( '/', $oldUrlPath );
+					if ( empty( end( $oldUrlPathArr ) ) || $flag ) {
+						$slashChar = '/';
+					}
 				}
 			}
 
@@ -76,7 +83,7 @@ class EstateDetailUrl
 				$urlTemp .= $this->getSanitizeTitle( $title, $flag , $switchLocale);
 			}
 
-			$urlLsSwitcher = $baseUrl . $urlElements['path'] . $urlTemp . $slashChar;
+			$urlLsSwitcher = $baseUrl . $path . $urlTemp . $slashChar;
 
 			if ( ! empty( $getParameters ) ) {
 				$urlLsSwitcher .= '?' . http_build_query( $getParameters );
@@ -134,6 +141,10 @@ class EstateDetailUrl
 		$getParameters = [];
 		$urlElements   = wp_parse_url( $oldUrl );
 		$baseUrl       = UrlHelper::buildBaseUrl( $urlElements );
+		$path          = UrlHelper::getPath( $urlElements );
+		if ($baseUrl === '' || $path === '') {
+			return (string)$oldUrl;
+		}
 		$urlTemp       = $estateId;
 		$tickerUrlHasTitleFlag = false;
 
@@ -150,7 +161,7 @@ class EstateDetailUrl
 			parse_str( $urlElements['query'], $getParameters );
 		}
 
-		$oldUrlPathArr = explode( '/', $urlElements['path'] );
+		$oldUrlPathArr = explode( '/', $path );
 		if ( empty( end( $oldUrlPathArr ) ) ) {
 			array_pop( $oldUrlPathArr );
 		}

--- a/plugin/Controller/EstateViewSimilarEstates.php
+++ b/plugin/Controller/EstateViewSimilarEstates.php
@@ -93,7 +93,8 @@ class EstateViewSimilarEstates
 		while ($pValuesCurrentEstate = $pEstateList->estateIterator
 			(EstateViewFieldModifierTypes::MODIFIER_TYPE_DETAIL_SIMILAR_ESTATES)) {
 			$this->_pFilterConfiguration->setEstateKind($pValuesCurrentEstate->getValueRaw('objektart') ?? '');
-			$this->_pFilterConfiguration->setMarketingMethod($pValuesCurrentEstate->getValueRaw('vermarktungsart') ?? '');
+			$marketingMethod = (string)($pValuesCurrentEstate->getValueRaw('vermarktungsart') ?? '');
+			$this->_pFilterConfiguration->setMarketingMethod(mb_strtolower($marketingMethod));
 			$this->_pFilterConfiguration->setStreet($pValuesCurrentEstate->getValueRaw('strasse') ?? '');
 			$this->_pFilterConfiguration->setCountry($pValuesCurrentEstate->getValueRaw('land') ?? '');
 			$this->_pFilterConfiguration->setPostalCode($pValuesCurrentEstate->getValueRaw('plz') ?? '');

--- a/plugin/EstateDetail.php
+++ b/plugin/EstateDetail.php
@@ -258,9 +258,12 @@ class EstateDetail
 		$pDataViewSimilarEstates = $pDataSimilarSettings->getDataViewSimilarEstates();
 
 		$pSimilarEstates = new EstateViewSimilarEstates($pDataViewSimilarEstates);
+		if ($this->getEstateIds() === []) {
+			return '';
+		}
+
 		$pCopyThis = clone $this;
-		$pCopyThis->setFormatOutput(false);
-		$pCopyThis->loadEstates();
+		$pCopyThis->resetEstateIterator();
 		$pSimilarEstates->loadByMainEstates($pCopyThis);
 		return $pSimilarEstates->generateHtmlOutput($this->_estateId);
 	}

--- a/plugin/EstateFiles.php
+++ b/plugin/EstateFiles.php
@@ -170,6 +170,23 @@ class EstateFiles
 	 *
 	 */
 
+	/**
+	 * Public wrapper to allow batched processing of pre-fetched estate picture records.
+	 * Used by EstateList::loadEstates() for request batching.
+	 *
+	 * @param array $responseArrayEstatePictures
+	 */
+	public function collectEstateFilesFromRecords(array $responseArrayEstatePictures)
+	{
+		$this->collectEstateFiles($responseArrayEstatePictures);
+	}
+
+	/**
+	 *
+	 * @param array $responseArrayEstatePictures
+	 *
+	 */
+
 	private function collectEstateFiles($responseArrayEstatePictures)
 	{
 		foreach ($responseArrayEstatePictures as $fileEntry) {

--- a/plugin/EstateFiles.php
+++ b/plugin/EstateFiles.php
@@ -165,12 +165,6 @@ class EstateFiles
 	}
 
 	/**
-	 *
-	 * @param array $responseArrayEstatePictures
-	 *
-	 */
-
-	/**
 	 * Public wrapper to allow batched processing of pre-fetched estate picture records.
 	 * Used by EstateList::loadEstates() for request batching.
 	 *

--- a/plugin/EstateList.php
+++ b/plugin/EstateList.php
@@ -497,6 +497,10 @@ class EstateList
 			->addFieldsAddressEstate($pFieldsCollection)
 			->addFieldsEstateGeoPosisionBackend($pFieldsCollection);
 
+		if (in_array('regionaler_zusatz', $inputs->getFields(), true)) {
+			$pFieldBuilderShort->addFieldsAddressEstateWithRegionValues($pFieldsCollection);
+		}
+
 		foreach ($inputs->getFields() as $name) {
 			if ($pFieldsCollection->containsFieldByModule($recordType, $name)) {
 				$activeInputs[] = $name;
@@ -521,6 +525,10 @@ class EstateList
 		$pFieldBuilderShort
 			->addFieldsAddressEstate($pFieldsCollection)
 			->addFieldsEstateGeoPosisionBackend($pFieldsCollection);
+
+		if (in_array('regionaler_zusatz', $inputs->getFilterableFields(), true)) {
+			$pFieldBuilderShort->addFieldsAddressEstateWithRegionValues($pFieldsCollection);
+		}
 
 		foreach ($inputs->getFilterableFields() as $name) {
 			if ($pFieldsCollection->containsFieldByModule($recordType, $name)) {

--- a/plugin/EstateList.php
+++ b/plugin/EstateList.php
@@ -1312,7 +1312,10 @@ class EstateList
 		$pFieldsCollection = new FieldsCollection();
 		$pFieldsCollectionBuilderShort = $this->_pEnvironment->getFieldsCollectionBuilderShort();
 		$pFieldsCollectionBuilderShort->addFieldsAddressEstate($pFieldsCollection);
-		$pFieldsCollectionBuilderShort->addFieldsAddressEstateWithRegionValues($pFieldsCollection);
+		$filterableFields = $this->_pDataView->getFilterableFields();
+		if (in_array('regionaler_zusatz', $filterableFields, true)) {
+			$pFieldsCollectionBuilderShort->addFieldsAddressEstateWithRegionValues($pFieldsCollection);
+		}
 		if (!empty($this->_pDataView->getConvertTextToSelectForCityField())) {
 			$pFieldsCollectionBuilderShort->addFieldEstateCityValues($pFieldsCollection, $this->getShowReferenceEstate());
 		}

--- a/plugin/EstateList.php
+++ b/plugin/EstateList.php
@@ -23,6 +23,7 @@ namespace onOffice\WPlugin;
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+use DI\Container;
 use DI\ContainerBuilder;
 use DI\DependencyException;
 use DI\NotFoundException;
@@ -134,14 +135,16 @@ class EstateList
 	/**
 	 * @param DataView $pDataView
 	 * @param EstateListEnvironment $pEnvironment
+	 * @param Container|null $pContainer If null, a new container will be built (legacy).
+	 *        Pass the global DI container from plugin.php for better performance.
 	 * @throws DependencyException
 	 * @throws NotFoundException
 	 */
-	public function __construct(DataView $pDataView, EstateListEnvironment $pEnvironment = null)
+	public function __construct(DataView $pDataView, EstateListEnvironment $pEnvironment = null, Container $pContainer = null)
 	{
-		$pContainerBuilder = new ContainerBuilder;
-		$pContainerBuilder->addDefinitions(ONOFFICE_DI_CONFIG_PATH);
-		$pContainer = $pContainerBuilder->build();
+		if ($pContainer === null) {
+			$pContainer = self::getGlobalContainer();
+		}
 		$this->_pEnvironment = $pEnvironment ?? new EstateListEnvironmentDefault($pContainer);
 		$this->_pDataView = $pDataView;
 		$pSDKWrapper = $this->_pEnvironment->getSDKWrapper();
@@ -150,6 +153,23 @@ class EstateList
 		$this->_pLanguageSwitcher = $pContainer->get(EstateDetailUrl::class);
 		$this->_pWPOptionWrapper = $pContainer->get(WPOptionWrapperDefault::class);
 		$this->_redirectIfOldUrl = $pContainer->get(Redirector::class);
+	}
+
+	/**
+	 * Returns a shared global DI container instance.
+	 * Avoids rebuilding the container multiple times per request.
+	 *
+	 * @return Container
+	 */
+	private static function getGlobalContainer(): Container
+	{
+		static $pGlobalContainer = null;
+		if ($pGlobalContainer === null) {
+			$pContainerBuilder = new ContainerBuilder;
+			$pContainerBuilder->addDefinitions(ONOFFICE_DI_CONFIG_PATH);
+			$pGlobalContainer = $pContainerBuilder->build();
+		}
+		return $pGlobalContainer;
 	}
 
 	/**
@@ -211,12 +231,44 @@ class EstateList
 		$estateIds = $this->getEstateIdToForeignMapping($this->_records);
 
 		if ($estateIds !== []) {
-			$this->getEstateContactPerson($estateIds);
+			// --- BATCHED Phase 2: Queue idsfromrelation + estatepictures, send together ---
+			$pSDKWrapper = $this->_pEnvironment->getSDKWrapper();
 
+			// Queue idsfromrelation (contact persons)
+			$pRelationAction = new APIClientActionGeneric($pSDKWrapper, onOfficeSDK::ACTION_ID_GET, 'idsfromrelation');
+			$pRelationAction->setParameters([
+				'parentids' => array_keys($estateIds),
+				'relationtype' => onOfficeSDK::RELATION_TYPE_CONTACT_BROKER,
+			]);
+			$pRelationAction->addRequestToQueue();
+
+			// Queue estatepictures
 			$this->_pEstateFiles = $this->_pEnvironment->getEstateFiles();
+			$pPicturesAction = null;
+			if (count($fileCategories) > 0) {
+				$pPicturesAction = new APIClientActionGeneric($pSDKWrapper, onOfficeSDK::ACTION_ID_GET, 'estatepictures');
+				$pPicturesAction->setParameters([
+					'estateids' => array_values($estateIds),
+					'categories' => $fileCategories,
+					'language' => Language::getDefault(),
+				]);
+				$pPicturesAction->addRequestToQueue();
+			}
+
+			// Send idsfromrelation + estatepictures in ONE HTTP request
+			$pSDKWrapper->sendRequests();
+
+			// Process idsfromrelation results
+			$this->collectEstateContactPerson($pRelationAction->getResultRecords(), $estateIds);
+
+			// Process estatepictures results
+			if ($pPicturesAction !== null && $pPicturesAction->getResultStatus()) {
+				$this->_pEstateFiles->collectEstateFilesFromRecords($pPicturesAction->getResultRecords());
+			}
+
+			// --- BATCHED Phase 3: file GETs (already batched internally) ---
 			try {
-				$this->_pEstateFiles->getAllFiles($fileCategories, $estateIds, $this->_pEnvironment->getSDKWrapper());
-				$this->_pEstateFiles->getFilesByEstateIds($estateIds, $this->_pEnvironment->getSDKWrapper());
+				$this->_pEstateFiles->getFilesByEstateIds($estateIds, $pSDKWrapper);
 			} catch (\onOffice\SDK\Exception\HttpFetchNoResultException $e) {
 				// Estate files could not be fetched — continue without images
 			}

--- a/plugin/EstateList.php
+++ b/plugin/EstateList.php
@@ -495,7 +495,6 @@ class EstateList
 		$pFieldBuilderShort = $this->_pEnvironment->getContainer()->get(FieldsCollectionBuilderShort::class);
 		$pFieldBuilderShort
 			->addFieldsAddressEstate($pFieldsCollection)
-			->addFieldsAddressEstateWithRegionValues($pFieldsCollection)
 			->addFieldsEstateGeoPosisionBackend($pFieldsCollection);
 
 		foreach ($inputs->getFields() as $name) {
@@ -521,7 +520,6 @@ class EstateList
 		$pFieldBuilderShort = $this->_pEnvironment->getContainer()->get(FieldsCollectionBuilderShort::class);
 		$pFieldBuilderShort
 			->addFieldsAddressEstate($pFieldsCollection)
-			->addFieldsAddressEstateWithRegionValues($pFieldsCollection)
 			->addFieldsEstateGeoPosisionBackend($pFieldsCollection);
 
 		foreach ($inputs->getFilterableFields() as $name) {
@@ -805,7 +803,7 @@ class EstateList
 
 			$pDefaultFilterBuilder = new DefaultFilterBuilderDetailViewAddress();
 			$addressList->setDefaultFilterBuilder($pDefaultFilterBuilder);
-			$addressList->loadBrokerAddressesById($allAddressIds, $fields);
+			$addressList->loadBrokerAddressesById($allAddressIds, $fields, false);
 		}
 	}
 

--- a/plugin/EstateList.php
+++ b/plugin/EstateList.php
@@ -534,26 +534,6 @@ class EstateList
 	}
 
 	/**
-	 * @param array $estateIds
-	 * @throws DependencyException
-	 * @throws NotFoundException
-	 * @throws API\ApiClientException
-	 */
-	private function getEstateContactPerson(array $estateIds)
-	{
-		$pSDKWrapper = $this->_pEnvironment->getSDKWrapper();
-
-		$parameters = [
-			'parentids' => array_keys($estateIds),
-			'relationtype' => onOfficeSDK::RELATION_TYPE_CONTACT_BROKER,
-		];
-		$pAPIClientAction = new APIClientActionGeneric($pSDKWrapper, onOfficeSDK::ACTION_ID_GET, 'idsfromrelation');
-		$pAPIClientAction->setParameters($parameters);
-		$pAPIClientAction->addRequestToQueue()->sendRequests();
-		$this->collectEstateContactPerson($pAPIClientAction->getResultRecords(), $estateIds);
-	}
-
-	/**
 	 * @param string $lang
 	 * @param bool $formatOutput
 	 * @return array

--- a/plugin/Form.php
+++ b/plugin/Form.php
@@ -102,14 +102,20 @@ class Form
 		$this->setGenericSetting('submitButtonLabel', __('Submit', 'onoffice-for-wp-websites'));
 		$this->setGenericSetting('formId', 'onoffice-form');
 		$this->_pContainer = $pContainer ?? $this->buildContainer();
+		$pFormConfigFactory = $this->_pContainer->get(DataFormConfigurationFactory::class);
+		$pFormConfig = $pFormConfigFactory->loadByFormName($formName);
+
 		$pFieldsCollection = new FieldsCollection();
 		$pFieldBuilderShort = $this->_pContainer->get(FieldsCollectionBuilderShort::class);
 		$pFieldBuilderShort
 			->addFieldsAddressEstate($pFieldsCollection, true)
 			->addFieldsSearchCriteria($pFieldsCollection)
 			->addFieldsFormFrontend($pFieldsCollection)
-			->addCustomLabelFieldsFormFrontend($pFieldsCollection, $formName)
-			->addFieldsAddressEstateWithRegionValues($pFieldsCollection);
+			->addCustomLabelFieldsFormFrontend($pFieldsCollection, $formName);
+
+		if ($this->usesRegionalSupplementField($pFormConfig)) {
+			$pFieldBuilderShort->addFieldsAddressEstateWithRegionValues($pFieldsCollection);
+		}
 
 		if ($type === self::TYPE_INTEREST || $type === self::TYPE_APPLICANT_SEARCH) {
 			$pFieldBuilderShort->addFieldSupervisorForSearchCriteria($pFieldsCollection);
@@ -119,8 +125,6 @@ class Form
 		FormPost::incrementFormNo();
 		$this->_formNo = $pFormPost->getFormNo();
 
-		$pFormConfigFactory = $this->_pContainer->get(DataFormConfigurationFactory::class);
-		$pFormConfig = $pFormConfigFactory->loadByFormName($formName);
 		$this->_pFieldsCollection = $this->buildFieldsCollectionForForm($pFieldsCollection, $type, $pFormConfig);
 		try {
 			$this->_pFormData = $pFormPost->getFormDataInstance($formName, $this->_formNo);
@@ -138,6 +142,16 @@ class Form
 			$this->_pFormData->setValues
 				(['range' => $pGeoPositionDefaults->getRadiusValue()] + $this->getDefaultValues());
 		}
+	}
+
+	/**
+	 * @param DataFormConfiguration $pConfiguration
+	 * @return bool
+	 */
+	private function usesRegionalSupplementField(DataFormConfiguration $pConfiguration): bool
+	{
+		$inputs = $pConfiguration->getInputs();
+		return array_key_exists('regionaler_zusatz', $inputs);
 	}
 
 	/**

--- a/plugin/Form.php
+++ b/plugin/Form.php
@@ -151,7 +151,19 @@ class Form
 	private function usesRegionalSupplementField(DataFormConfiguration $pConfiguration): bool
 	{
 		$inputs = $pConfiguration->getInputs();
-		return array_key_exists('regionaler_zusatz', $inputs);
+		if (array_key_exists('regionaler_zusatz', $inputs)) {
+			return true;
+		}
+
+		if (in_array('regionaler_zusatz', $pConfiguration->getRequiredFields(), true)) {
+			return true;
+		}
+
+		if (in_array('regionaler_zusatz', $pConfiguration->getHiddenFields(), true)) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/plugin/SDKWrapper.php
+++ b/plugin/SDKWrapper.php
@@ -70,8 +70,6 @@ class SDKWrapper
 	/** @var array<string, array> */
 	private $_cachedFieldTypesByLanguage = [];
 
-	/** @var array<string, bool> */
-	private $_renewedListCacheByKey = [];
 
 	/**
 	 * @var  SymmetricEncryption
@@ -138,8 +136,6 @@ class SDKWrapper
 		$parameters = $pApiAction->getParameters();
 		$callback = $pApiAction->getResultCallback();
 
-		//$this->ensureListCacheWarmIfNeeded($actionId, $resourceId, $identifier, $resourceType, $parameters);
-
 		$id = $this->_pSDK->call($actionId, $resourceId, $identifier, $resourceType, $parameters);
 
 		if ($callback !== null) {
@@ -147,57 +143,6 @@ class SDKWrapper
 		}
 
 		return $id;
-	}
-
-	/**
-	 * TODO: Testing this function - if not used, will be removed.
-	 * 
-	 * Warm list cache once per list/language when cache is missing or incomplete.
-	 *
-	 * @param string $actionId
-	 * @param string $resourceId
-	 * @param string|null $identifier
-	 * @param string $resourceType
-	 * @param array $parameters
-	 */
-	private function ensureListCacheWarmIfNeeded(
-		string $actionId,
-		string $resourceId,
-		$identifier,
-		string $resourceType,
-		array $parameters
-	): void {
-		if (!isset($parameters['listname']) || !array_key_exists('params_list_cache', $parameters)) {
-			return;
-		}
-
-		$cacheResponse = $this->_pSDK->callFromCache(
-			$actionId,
-			$resourceId,
-			$identifier,
-			$resourceType,
-			$parameters['params_list_cache']
-		);
-
-		$needsDerivedListData = ($parameters['formatoutput'] ?? false) === true;
-		$hasDerivedListData = is_array($cacheResponse)
-			&& isset($cacheResponse['raw']['data']['records'])
-			&& is_array($cacheResponse['raw']['data']['records'])
-			&& isset($cacheResponse['types'])
-			&& is_array($cacheResponse['types']);
-
-		if ($cacheResponse != null && (!$needsDerivedListData || $hasDerivedListData)) {
-			return;
-		}
-
-		$language = $parameters['outputlanguage'] ?? Language::getDefault();
-		$listCacheKey = sprintf('%s|%s', (string)$parameters['listname'], (string)$language);
-		if (isset($this->_renewedListCacheByKey[$listCacheKey])) {
-			return;
-		}
-
-		$this->renewCache($parameters['listname'], [$language]);
-		$this->_renewedListCacheByKey[$listCacheKey] = true;
 	}
 
 

--- a/plugin/SDKWrapper.php
+++ b/plugin/SDKWrapper.php
@@ -67,6 +67,9 @@ class SDKWrapper
 	/** @var array */
 	private $_caches = [];
 
+	/** @var array<string, array> */
+	private $_cachedFieldTypesByLanguage = [];
+
 	/**
 	 * @var  SymmetricEncryption
 	 */
@@ -133,14 +136,26 @@ class SDKWrapper
 		$callback = $pApiAction->getResultCallback();
 
 
-		//1 check is call for a list
-		if(isset($parameters['listname']) && array_key_exists('params_list_cache',$parameters))
-		{
-			//2 check is list-data in Cache
-			$cacheResponse = $this->_pSDK->callFromCache($actionId, $resourceId, $identifier, $resourceType, $parameters['params_list_cache']);
-			if($cacheResponse == null)
-			{
-				$this->renewCache($parameters['listname']);
+		// Check list cache and warm it if missing.
+		if (isset($parameters['listname']) && array_key_exists('params_list_cache', $parameters)) {
+			$cacheResponse = $this->_pSDK->callFromCache(
+				$actionId,
+				$resourceId,
+				$identifier,
+				$resourceType,
+				$parameters['params_list_cache']
+			);
+
+			$needsDerivedListData = ($parameters['formatoutput'] ?? false) === true;
+			$hasDerivedListData = is_array($cacheResponse)
+				&& isset($cacheResponse['raw']['data']['records'])
+				&& is_array($cacheResponse['raw']['data']['records'])
+				&& isset($cacheResponse['types'])
+				&& is_array($cacheResponse['types']);
+
+			if ($cacheResponse == null || ($needsDerivedListData && !$hasDerivedListData)) {
+				$language = $parameters['outputlanguage'] ?? Language::getDefault();
+				$this->renewCache($parameters['listname'], [$language]);
 			}
 		}
 
@@ -216,7 +231,7 @@ class SDKWrapper
 	 * (does not create cache for detail pages and similar objects)
 	 *
 	 */
-	 public function renewCache(string $listName = null)
+	 public function renewCache(string $listName = null, array $languages = null)
 	 {
 			//1 get all lists
 			//2 clean Cache
@@ -227,7 +242,11 @@ class SDKWrapper
 			$pDefaultFilterBuilderFactory = $this->_pContainer->get(DefaultFilterBuilderFactory::class);
 			$pDefaultFilterBuilderListViewAddressFactory = $this->_pContainer->get(DefaultFilterBuilderListViewAddressFactory::class);
 
-			$languages = Language::getAllWPMLLanguages();
+			if ($languages === null || $languages === []) {
+				$languages = Language::getAllWPMLLanguages();
+			} else {
+				$languages = array_values(array_unique($languages));
+			}
 			$estateLists = $this->getEstateLists($listName);
 			$addressLists = $this->getAddressLists($listName);
 			$this->_caches = [new DBCache(['ttl' => 3600])];
@@ -293,6 +312,13 @@ class SDKWrapper
 	 {
 		$fieldsByModule = [];
 		foreach ($languages as $lang) {
+			if (isset($this->_cachedFieldTypesByLanguage[$lang])) {
+				foreach ($this->_cachedFieldTypesByLanguage[$lang] as $module => $moduleFields) {
+					$fieldsByModule[$module] = $moduleFields;
+				}
+				continue;
+			}
+
 			$parametersGetFieldList = [
 				'labels' => true,
 				'showContent' => true,
@@ -307,12 +333,16 @@ class SDKWrapper
 			$pApiClientActionFields->addRequestToQueue()->sendRequests();
 
 			$records = $pApiClientActionFields->getResultRecords();
+			$fieldTypesForLanguage = [];
 			foreach ($records as $moduleProperties) {
 				foreach ($moduleProperties['elements'] as $fieldName => $fieldProperties) {
-					if($fieldName != 'label')
+					if ($fieldName != 'label') {
+						$fieldTypesForLanguage[$moduleProperties['id']][$fieldName] = $fieldProperties['type'];
 						$fieldsByModule[$moduleProperties['id']][$fieldName] = $fieldProperties['type'];
+					}
 				}
 			}
+			$this->_cachedFieldTypesByLanguage[$lang] = $fieldTypesForLanguage;
 		}
 		return $fieldsByModule;
 	}

--- a/plugin/SDKWrapper.php
+++ b/plugin/SDKWrapper.php
@@ -219,11 +219,7 @@ class SDKWrapper
 			$pDefaultFilterBuilderFactory = $this->_pContainer->get(DefaultFilterBuilderFactory::class);
 			$pDefaultFilterBuilderListViewAddressFactory = $this->_pContainer->get(DefaultFilterBuilderListViewAddressFactory::class);
 
-			if ($languages === null || $languages === []) {
-				$languages = Language::getAllWPMLLanguages();
-			} else {
-				$languages = array_values(array_unique($languages));
-			}
+			$languages = $this->normalizeLanguages($languages);
 			$estateLists = $this->getEstateLists($listName);
 			$addressLists = $this->getAddressLists($listName);
 			$this->_caches = [new DBCache(['ttl' => 3600])];
@@ -280,6 +276,39 @@ class SDKWrapper
 				}
 			}
 	 }
+
+	/**
+	 * Normalize and validate onOffice language codes.
+	 * Falls back to the default language when none are valid.
+	 *
+	 * @param array|null $languages
+	 * @return array
+	 */
+	private function normalizeLanguages(array $languages = null): array
+	{
+		if ($languages === null || $languages === []) {
+			$languages = Language::getAllWPMLLanguages();
+		}
+
+		$allowedLanguages = array_values(array_unique(array_values(Language::LOCALE_MAPPING)));
+		$allowedLanguageLookup = array_fill_keys($allowedLanguages, true);
+
+		$normalizedLanguages = [];
+		foreach ($languages as $language) {
+			if (!is_string($language)) {
+				continue;
+			}
+
+			$language = strtoupper(trim($language));
+			if ($language !== '' && isset($allowedLanguageLookup[$language])) {
+				$normalizedLanguages[] = $language;
+			}
+		}
+
+		$normalizedLanguages = array_values(array_unique($normalizedLanguages));
+
+		return $normalizedLanguages === [] ? [Language::getDefault()] : $normalizedLanguages;
+	}
 	/**
 	 * return all Fields from Api, to save in Cache
 	 * @param array $language

--- a/plugin/SDKWrapper.php
+++ b/plugin/SDKWrapper.php
@@ -194,7 +194,11 @@ class SDKWrapper
 		$records = $pApiClientAction->getResult();
 		$resultMeta = $pApiClientAction->getResultMeta();
 
-		$numpages = ceil($resultMeta['cntabsolute']/500);
+		$cntAbsolute = $resultMeta['cntabsolute'] ?? 0;
+		if (is_array($cntAbsolute)) {
+			$cntAbsolute = $cntAbsolute[0] ?? 0;
+		}
+		$numpages = ceil(intval($cntAbsolute) / 500);
 		//2 loop over other pages
 		if($page == 1 && $numpages > 1)
 		{

--- a/plugin/SDKWrapper.php
+++ b/plugin/SDKWrapper.php
@@ -105,12 +105,12 @@ class SDKWrapper
 		$this->_pContainer = self::$_pSharedContainer;
 		$this->_encrypter = $this->_pContainer->make(SymmetricEncryption::class);
 		$this->_pSDK->setCaches($this->_caches);
-		$this->_pSDK->setApiServer('https://api.onoffice.de/api/');
+		$this->_pSDK->setApiServer(ONOFFICE_API_SERVER);
 		$this->_pSDK->setApiVersion('latest');
 		$this->_pSDK->setApiCurlOptions(
 			[
 				CURLOPT_SSL_VERIFYPEER => true,
-				CURLOPT_PROTOCOLS => CURLPROTO_HTTPS
+				CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS
 			]
 		);
 	}

--- a/plugin/SDKWrapper.php
+++ b/plugin/SDKWrapper.php
@@ -138,33 +138,7 @@ class SDKWrapper
 		$parameters = $pApiAction->getParameters();
 		$callback = $pApiAction->getResultCallback();
 
-
-		// Check list cache and warm it if missing.
-		if (isset($parameters['listname']) && array_key_exists('params_list_cache', $parameters)) {
-			$cacheResponse = $this->_pSDK->callFromCache(
-				$actionId,
-				$resourceId,
-				$identifier,
-				$resourceType,
-				$parameters['params_list_cache']
-			);
-
-			$needsDerivedListData = ($parameters['formatoutput'] ?? false) === true;
-			$hasDerivedListData = is_array($cacheResponse)
-				&& isset($cacheResponse['raw']['data']['records'])
-				&& is_array($cacheResponse['raw']['data']['records'])
-				&& isset($cacheResponse['types'])
-				&& is_array($cacheResponse['types']);
-
-			if ($cacheResponse == null || ($needsDerivedListData && !$hasDerivedListData)) {
-				$language = $parameters['outputlanguage'] ?? Language::getDefault();
-				$listCacheKey = sprintf('%s|%s', (string)$parameters['listname'], (string)$language);
-				if (!isset($this->_renewedListCacheByKey[$listCacheKey])) {
-					$this->renewCache($parameters['listname'], [$language]);
-					$this->_renewedListCacheByKey[$listCacheKey] = true;
-				}
-			}
-		}
+		$this->ensureListCacheWarmIfNeeded($actionId, $resourceId, $identifier, $resourceType, $parameters);
 
 		$id = $this->_pSDK->call($actionId, $resourceId, $identifier, $resourceType, $parameters);
 
@@ -173,6 +147,55 @@ class SDKWrapper
 		}
 
 		return $id;
+	}
+
+	/**
+	 * Warm list cache once per list/language when cache is missing or incomplete.
+	 *
+	 * @param string $actionId
+	 * @param string $resourceId
+	 * @param string|null $identifier
+	 * @param string $resourceType
+	 * @param array $parameters
+	 */
+	private function ensureListCacheWarmIfNeeded(
+		string $actionId,
+		string $resourceId,
+		$identifier,
+		string $resourceType,
+		array $parameters
+	): void {
+		if (!isset($parameters['listname']) || !array_key_exists('params_list_cache', $parameters)) {
+			return;
+		}
+
+		$cacheResponse = $this->_pSDK->callFromCache(
+			$actionId,
+			$resourceId,
+			$identifier,
+			$resourceType,
+			$parameters['params_list_cache']
+		);
+
+		$needsDerivedListData = ($parameters['formatoutput'] ?? false) === true;
+		$hasDerivedListData = is_array($cacheResponse)
+			&& isset($cacheResponse['raw']['data']['records'])
+			&& is_array($cacheResponse['raw']['data']['records'])
+			&& isset($cacheResponse['types'])
+			&& is_array($cacheResponse['types']);
+
+		if ($cacheResponse != null && (!$needsDerivedListData || $hasDerivedListData)) {
+			return;
+		}
+
+		$language = $parameters['outputlanguage'] ?? Language::getDefault();
+		$listCacheKey = sprintf('%s|%s', (string)$parameters['listname'], (string)$language);
+		if (isset($this->_renewedListCacheByKey[$listCacheKey])) {
+			return;
+		}
+
+		$this->renewCache($parameters['listname'], [$language]);
+		$this->_renewedListCacheByKey[$listCacheKey] = true;
 	}
 
 

--- a/plugin/SDKWrapper.php
+++ b/plugin/SDKWrapper.php
@@ -70,6 +70,9 @@ class SDKWrapper
 	/** @var array<string, array> */
 	private $_cachedFieldTypesByLanguage = [];
 
+	/** @var array<string, bool> */
+	private $_renewedListCacheByKey = [];
+
 	/**
 	 * @var  SymmetricEncryption
 	 */
@@ -155,7 +158,11 @@ class SDKWrapper
 
 			if ($cacheResponse == null || ($needsDerivedListData && !$hasDerivedListData)) {
 				$language = $parameters['outputlanguage'] ?? Language::getDefault();
-				$this->renewCache($parameters['listname'], [$language]);
+				$listCacheKey = sprintf('%s|%s', (string)$parameters['listname'], (string)$language);
+				if (!isset($this->_renewedListCacheByKey[$listCacheKey])) {
+					$this->renewCache($parameters['listname'], [$language]);
+					$this->_renewedListCacheByKey[$listCacheKey] = true;
+				}
 			}
 		}
 

--- a/plugin/SDKWrapper.php
+++ b/plugin/SDKWrapper.php
@@ -83,6 +83,9 @@ class SDKWrapper
 	 *
 	 */
 
+	/** @var \DI\Container Shared container instance to avoid rebuilding */
+	private static $_pSharedContainer = null;
+
 	public function __construct(
 		onOfficeSDK $pSDK = null,
 		WPOptionWrapperBase $pWPOptionWrapper = null)
@@ -94,9 +97,12 @@ class SDKWrapper
 			new DBCache(['ttl' => 3600]),
 		];
 
-		$pDIContainerBuilder = new ContainerBuilder();
-		$pDIContainerBuilder->addDefinitions(ONOFFICE_DI_CONFIG_PATH);
-		$this->_pContainer = $pDIContainerBuilder->build();
+		if (self::$_pSharedContainer === null) {
+			$pDIContainerBuilder = new ContainerBuilder();
+			$pDIContainerBuilder->addDefinitions(ONOFFICE_DI_CONFIG_PATH);
+			self::$_pSharedContainer = $pDIContainerBuilder->build();
+		}
+		$this->_pContainer = self::$_pSharedContainer;
 		$this->_encrypter = $this->_pContainer->make(SymmetricEncryption::class);
 		$this->_pSDK->setCaches($this->_caches);
 		$this->_pSDK->setApiServer('https://api.onoffice.de/api/');

--- a/plugin/SDKWrapper.php
+++ b/plugin/SDKWrapper.php
@@ -138,7 +138,7 @@ class SDKWrapper
 		$parameters = $pApiAction->getParameters();
 		$callback = $pApiAction->getResultCallback();
 
-		$this->ensureListCacheWarmIfNeeded($actionId, $resourceId, $identifier, $resourceType, $parameters);
+		//$this->ensureListCacheWarmIfNeeded($actionId, $resourceId, $identifier, $resourceType, $parameters);
 
 		$id = $this->_pSDK->call($actionId, $resourceId, $identifier, $resourceType, $parameters);
 
@@ -150,6 +150,8 @@ class SDKWrapper
 	}
 
 	/**
+	 * TODO: Testing this function - if not used, will be removed.
+	 * 
 	 * Warm list cache once per list/language when cache is missing or incomplete.
 	 *
 	 * @param string $actionId

--- a/plugin/Utility/UrlHelper.php
+++ b/plugin/Utility/UrlHelper.php
@@ -26,17 +26,41 @@ namespace onOffice\WPlugin\Utility;
 class UrlHelper
 {
 	/**
-	 * @param array $urlElements
+	 * @param mixed $urlElements
 	 * @return string
 	 */
-	public static function buildBaseUrl(array $urlElements): string
+	public static function buildBaseUrl($urlElements): string
 	{
-		$baseUrl = $urlElements['scheme'] . '://' . $urlElements['host'];
+		if (!is_array($urlElements)) {
+			return '';
+		}
+
+		$scheme = $urlElements['scheme'] ?? '';
+		$host = $urlElements['host'] ?? '';
+
+		if ($scheme === '' || $host === '') {
+			return '';
+		}
+
+		$baseUrl = $scheme . '://' . $host;
 
 		if (isset($urlElements['port'])) {
 			$baseUrl .= ':' . $urlElements['port'];
 		}
 
 		return $baseUrl;
+	}
+
+	/**
+	 * @param mixed $urlElements
+	 * @return string
+	 */
+	public static function getPath($urlElements): string
+	{
+		if (!is_array($urlElements)) {
+			return '';
+		}
+
+		return is_string($urlElements['path'] ?? null) ? $urlElements['path'] : '';
 	}
 }

--- a/plugin/Utility/UrlHelper.php
+++ b/plugin/Utility/UrlHelper.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ *
+ *    Copyright (C) 2026 onOffice GmbH
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Affero General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace onOffice\WPlugin\Utility;
+
+class UrlHelper
+{
+	/**
+	 * @param array $urlElements
+	 * @return string
+	 */
+	public static function buildBaseUrl(array $urlElements): string
+	{
+		$baseUrl = $urlElements['scheme'] . '://' . $urlElements['host'];
+
+		if (isset($urlElements['port'])) {
+			$baseUrl .= ':' . $urlElements['port'];
+		}
+
+		return $baseUrl;
+	}
+}

--- a/tests/TestClassAddressDetailUrl.php
+++ b/tests/TestClassAddressDetailUrl.php
@@ -80,6 +80,20 @@ class TestClassAddressDetailUrl
 	 * @throws \DI\DependencyException
 	 * @throws \DI\NotFoundException
 	 */
+	public function testUrlWithCustomPort()
+	{
+		$addressId = 123;
+		$pInstance = $this->_pContainer->get(AddressDetailUrl::class);
+		$url = 'https://www.onoffice.de:8080/detail/?lang=en';
+		$expectedUrl = 'https://www.onoffice.de:8080/detail/123?lang=en';
+
+		$this->assertEquals($expectedUrl, $pInstance->createAddressDetailLink($url, $addressId));
+	}
+
+	/**
+	 * @throws \DI\DependencyException
+	 * @throws \DI\NotFoundException
+	 */
 	public function testAddressDetailUrl()
 	{
 		add_option('onoffice-address-detail-view-showInfoUserUrl', true);
@@ -138,6 +152,23 @@ class TestClassAddressDetailUrl
 		$pInstance = $this->_pContainer->get(AddressDetailUrl::class);
 		$url = 'https://www.onoffice.de/detail/123?lang=en';
 		$expectedUrl = 'https://www.onoffice.de/detail/123-test-title?lang=en';
+		$this->assertEquals($expectedUrl, $pInstance->getUrlWithAddressTitle($addressId, $title, $url, false, $pAddressRedirection));
+	}
+
+	/**
+	 * @throws \DI\DependencyException
+	 * @throws \DI\NotFoundException
+	 */
+	public function testGetUrlWithFilterTrueAndEnableOptionShowTitleKeepsCustomPort()
+	{
+		$pAddressRedirection = apply_filters('oo_is_address_detail_page_redirection', true);
+		add_option('onoffice-address-detail-view-showInfoUserUrl', true);
+		$addressId = 123;
+		$title = 'test-title';
+		$pInstance = $this->_pContainer->get(AddressDetailUrl::class);
+		$url = 'https://www.onoffice.de:8080/detail/123?lang=en';
+		$expectedUrl = 'https://www.onoffice.de:8080/detail/123-test-title?lang=en';
+
 		$this->assertEquals($expectedUrl, $pInstance->getUrlWithAddressTitle($addressId, $title, $url, false, $pAddressRedirection));
 	}
 

--- a/tests/TestClassEstateDetailUrl.php
+++ b/tests/TestClassEstateDetailUrl.php
@@ -80,6 +80,20 @@ class TestClassEstateDetailUrl
 	 * @throws \DI\DependencyException
 	 * @throws \DI\NotFoundException
 	 */
+	public function testUrlWithCustomPort()
+	{
+		$estateId = 123;
+		$pInstance = $this->_pContainer->get(EstateDetailUrl::class);
+		$url = 'https://www.onoffice.de:8080/detail/?lang=en';
+		$expectedUrl = 'https://www.onoffice.de:8080/detail/123?lang=en';
+
+		$this->assertEquals($expectedUrl, $pInstance->createEstateDetailLink($url, $estateId));
+	}
+
+	/**
+	 * @throws \DI\DependencyException
+	 * @throws \DI\NotFoundException
+	 */
 	public function testUrlWithTitle()
 	{
 		add_option('onoffice-detail-view-showTitleUrl', true);
@@ -154,6 +168,23 @@ class TestClassEstateDetailUrl
 		$pInstance = $this->_pContainer->get(EstateDetailUrl::class);
 		$url = 'https://www.onoffice.de/detail/123?lang=en';
 		$expectedUrl = 'https://www.onoffice.de/detail/123-test-title?lang=en';
+		$this->assertEquals($expectedUrl, $pInstance->getUrlWithEstateTitle($estateId, $title, $url, false, $pEstateRedirection));
+	}
+
+	/**
+	 * @throws \DI\DependencyException
+	 * @throws \DI\NotFoundException
+	 */
+	public function testGetUrlWithFilterTrueAndEnableOptionShowTitleKeepsCustomPort()
+	{
+		$pEstateRedirection = apply_filters('oo_is_detailpage_redirection', true);
+		add_option('onoffice-detail-view-showTitleUrl', true);
+		$estateId = 123;
+		$title = 'test-title';
+		$pInstance = $this->_pContainer->get(EstateDetailUrl::class);
+		$url = 'https://www.onoffice.de:8080/detail/123?lang=en';
+		$expectedUrl = 'https://www.onoffice.de:8080/detail/123-test-title?lang=en';
+
 		$this->assertEquals($expectedUrl, $pInstance->getUrlWithEstateTitle($estateId, $title, $url, false, $pEstateRedirection));
 	}
 


### PR DESCRIPTION
This PR improves overall plugin performance by reducing redundant API calls, batching requests more efficiently, and tightening cache behavior. It also includes URL handling fixes for custom ports.

## Measured Improvement (Local)
The following request-count improvements were recorded locally. Results can vary depending on the WP website configuration.

| Page type | Before | After | Reduction | Improvement |
| --- | ---: | ---: | ---: | ---: |
| Estate list | 42 | 17 | 25 | 59.5% |
| Estate detail | 27 | 13 | 14 | 51.9% |
| Generic pages | 7 | 2 | 5 | 71.4% |
| **Total** | **76** | **32** | **44** | **57.9%** |

## Summary
- Introduces per-request in-memory API response caching and request deduplication to reduce duplicate network traffic.
- Optimizes estate/address loading flows by batching queued requests and removing unnecessary follow-up calls.
- Improves cache consistency and robustness for list responses, field dependencies, and pagination metadata handling.
- Fixes detail URL generation to preserve custom ports (for example `:8080`).
- Adds defensive and conditional loading improvements to avoid unnecessary data fetching in forms and list filters.

## Key Changes

### API and cache performance
- Added in-memory cache in `SDK/src/internal/ApiCall.php` to reuse identical calls within the same PHP request.
- Deduplicates identical queued requests in a single send cycle and reuses source response/error results.
- Normalizes `fields` requests (including `showfielddependencies`) to improve cache hit consistency.
- Extracted and centralized cached list filtering, sorting, and pagination logic and added safety guards for incomplete payloads.
- Writes cache entries using normalized request parameters for better cache coherence.

### SDK/container/runtime optimizations
- `plugin/SDKWrapper.php` now reuses a shared DI container instead of rebuilding it repeatedly.
- Added in-memory caching of field-type metadata per language.
- `renewCache()` now supports optional language scoping and handles edge cases in `cntabsolute`.
- Introduced helper logic to warm list cache once per list/language when needed (currently not actively used).

### Estate/address request batching
- `plugin/EstateList.php` now batches `idsfromrelation` and `estatepictures` requests before a single `sendRequests()`.
- Estate file handling now processes pre-fetched picture records and avoids redundant request paths.
- `plugin/AddressList.php` now batches formatted/raw address reads and batches count-estate lookups.
- Added optional flag to skip related-estate enrichment when loading broker addresses where not required.

### Conditional field loading and behavior fixes
- Regional supplement field loading is now conditional in `plugin/EstateList.php` and `plugin/Form.php` (only when actually needed/configured).
- `plugin/EstateDetail.php` avoids unnecessary reload work for similar estates and exits early when no estate IDs are present.
- `plugin/Controller/EstateViewSimilarEstates.php` normalizes marketing method values to lowercase for filter matching consistency.

### URL handling
- Added `plugin/Utility/UrlHelper.php` to build base URLs including optional port.
- Updated `plugin/Controller/EstateDetailUrl.php` and `plugin/Controller/AddressDetailUrl.php` to preserve custom ports in generated detail/title URLs.