### PR TITLE
fix: include filter parameters in DBCache key for estate list queries

### DIFF
--- a/plugin/Cache/DBCache.php
+++ b/plugin/Cache/DBCache.php
@@ -89,7 +89,8 @@ class DBCache
 		$parametersSerialized = $this->getParametersSerialized( $parameters );
 		if(isset($parameters['parameters']['listname']))
 		{
-			$parametersSerialized = $parameters['parameters']['listname'].intval($parameters['parameters']['formatoutput']).$parameters['parameters']['outputlanguage'];
+			$filterKey = isset($parameters['parameters']['filter']) ? serialize($parameters['parameters']['filter']) : '';
+			$parametersSerialized = $parameters['parameters']['listname'].intval($parameters['parameters']['formatoutput']).$parameters['parameters']['outputlanguage'].$filterKey;
 		}
 		$parametersHashed = md5( $parametersSerialized );
 		return $parametersHashed;


### PR DESCRIPTION
## Problem

When a user performs a filtered estate search (e.g. purchase type + max price), the results are ignored and the unfiltered list is returned instead.

**Root cause:** `DBCache::getParametersHashed()` computes a shortened cache key for estate list requests — using only `listname`, `formatoutput`, and `outputlanguage`. User-supplied filter parameters are not included in the key. This means every search query against the same list view shares a single cache entry, regardless of what filters the user applied.

```php
// Before (buggy): all queries for the same listname share one cache entry
if(isset($parameters['parameters']['listname']))
{
    $parametersSerialized = $parameters['parameters']['listname']
        .intval($parameters['parameters']['formatoutput'])
        .$parameters['parameters']['outputlanguage'];
}
```

The problem is compounded by the `oo_cache_renew` cron job introduced in v6.0: it pre-warms the cache using `getEstateListParametersForCache()` (default filter only, no user input). Because the cache key ignores filters, this warm-up entry is then served for all subsequent filtered requests within the TTL window.

**Reproduction:**
1. Configure an estate list view with multiple properties (e.g. 85 total)
2. Visit the list page unfiltered — the result (85 items) gets cached
3. Within the cache TTL, apply a filter that should narrow the results (e.g. `vermarktungsart=kauf` + `kaufpreis__bis=100000` → expected: 1 result)
4. Actual result: still 85 items (cached unfiltered response is returned)

## Fix

Include the `filter` parameter in the cache key when `listname` is present:

```php
if(isset($parameters['parameters']['listname']))
{
    $filterKey = isset($parameters['parameters']['filter']) ? serialize($parameters['parameters']['filter']) : '';
    $parametersSerialized = $parameters['parameters']['listname']
        .intval($parameters['parameters']['formatoutput'])
        .$parameters['parameters']['outputlanguage']
        .$filterKey;
}
```

Each unique filter combination now gets its own cache entry. The cron pre-warming (which uses the default filter) continues to work correctly and populates its own entry without interfering with user search queries.

## Notes

- Backwards-compatible — no schema changes, no new options
- The cron pre-warming behavior in `getEstateListParametersForCache()` is preserved; only the cache key scope is widened
- Depending on your caching strategy, it may be worth considering whether additional parameters (e.g. `sortorder`, pagination offset) should also be included in the key