### PR TITLE
Fix: cache key collisions for unit estate lists

### DIFF
--- a/plugin/Cache/DBCache.php
+++ b/plugin/Cache/DBCache.php
@@ -90,9 +90,12 @@ class DBCache
 		if(isset($parameters['parameters']['listname']))
 		{
 			$parametersSerialized = $parameters['parameters']['listname'].intval($parameters['parameters']['formatoutput']).$parameters['parameters']['outputlanguage'];
+			// Append ID filters to the cache key to guarantee uniqueness for identity-based lists (like unit lists with sub-estates).
+			if (isset($parameters['parameters']['filter']['Id'])) {
+				$parametersSerialized .= serialize($parameters['parameters']['filter']['Id']);
+			}
 		}
-		$parametersHashed = md5( $parametersSerialized );
-		return $parametersHashed;
+		return md5( $parametersSerialized );
 	}
 
 


### PR DESCRIPTION
Fehler nachstellen:

1. Rufe Stammobjekt A mit Einheiten 1, 2, 3 auf.
1.1. Die Anzeige der Einheiten ist korrekt: 1, 2, 3
2. Rufe Stammobjekt B mit Einheiten 4, 5 auf
2.1. Die Anzeige der Einheiten ist falsch: 1, 2, 3

Das Problem war, dass der Key, der entscheidet, ob die Liste schon gecached wurde oder nicht, anhand des listname+formatoutput+outputlanguage zusammengesetzt wird.
Darum hat jede Einheitenliste den selben Key, wenn eine Detailseite eines Stammobjektes aufgerufen wird. 
