### PR TITLE
change(P#1670978): Github Actions Release

### DIFF
--- a/.github/workflows/create-prerelease.yml
+++ b/.github/workflows/create-prerelease.yml
@@ -3,6 +3,11 @@ name: 🧪 Create prerelease
 on:
   workflow_dispatch:
     inputs:
+      source-branch:
+        description: Branch to merge into prerelease
+        required: true
+        default: master
+        type: string
       auto_build:
         description: 'Beta-Image nach Deploy automatisch bauen?'
         type: boolean
@@ -15,6 +20,7 @@ jobs:
   merge:
     uses: ./.github/workflows/merge-source-into-branch.yml
     with:
+      source-branch: ${{ inputs.source-branch }}
       target-branch: prerelease
       auto_build: ${{ inputs.auto_build == true }}
     secrets: inherit

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -2,6 +2,12 @@ name: 🚀 Create release
 
 on:
   workflow_dispatch:
+    inputs:
+      source-branch:
+        description: Branch to merge into release
+        required: true
+        default: prerelease
+        type: string
 
 permissions:
   contents: write
@@ -10,5 +16,6 @@ jobs:
   merge:
     uses: ./.github/workflows/merge-source-into-branch.yml
     with:
+      source-branch: ${{ inputs.source-branch }}
       target-branch: release
     secrets: inherit

--- a/.github/workflows/merge-source-into-branch.yml
+++ b/.github/workflows/merge-source-into-branch.yml
@@ -75,11 +75,11 @@ jobs:
           fi
 
           merge_failed=false
+          NO_FF=""
           if [ "${TARGET_BRANCH}" = "release" ]; then
-            git merge --no-edit --no-ff -X theirs "origin/${SOURCE_BRANCH}" || merge_failed=true
-          else
-            git merge --no-edit -X theirs "origin/${SOURCE_BRANCH}" || merge_failed=true
+            NO_FF="--no-ff"
           fi
+          git merge --no-edit ${NO_FF} -X theirs "origin/${SOURCE_BRANCH}" || merge_failed=true
 
           if git diff --name-only --diff-filter=U | grep -q .; then
             while IFS= read -r path; do

--- a/.github/workflows/merge-source-into-branch.yml
+++ b/.github/workflows/merge-source-into-branch.yml
@@ -74,7 +74,26 @@ jobs:
             git checkout -B "${TARGET_BRANCH}" "origin/${SOURCE_BRANCH}"
           fi
 
-          git merge --no-ff --no-edit -X theirs "origin/${SOURCE_BRANCH}"
+          merge_failed=false
+          if [ "${TARGET_BRANCH}" = "release" ]; then
+            git merge --no-edit --no-ff -X theirs "origin/${SOURCE_BRANCH}" || merge_failed=true
+          else
+            git merge --no-edit -X theirs "origin/${SOURCE_BRANCH}" || merge_failed=true
+          fi
+
+          if git diff --name-only --diff-filter=U | grep -q .; then
+            while IFS= read -r path; do
+              if git cat-file -e "origin/${SOURCE_BRANCH}:${path}" 2>/dev/null; then
+                git checkout "origin/${SOURCE_BRANCH}" -- "${path}"
+                git add "${path}"
+              else
+                git rm -f -- "${path}"
+              fi
+            done < <(git diff --name-only --diff-filter=U)
+            git commit --no-edit
+          elif [ "${merge_failed}" = "true" ]; then
+            exit 1
+          fi
 
           # release.yml reads the latest commit trailer on prerelease pushes and forwards it to the beta deploy job.
           if [ "${TARGET_BRANCH}" = "prerelease" ] && [ "${AUTO_BUILD}" = "true" ]; then

--- a/.github/workflows/merge-source-into-branch.yml
+++ b/.github/workflows/merge-source-into-branch.yml
@@ -3,6 +3,9 @@ name: Merge source into release branch
 on:
   workflow_call:
     inputs:
+      source-branch:
+        required: false
+        type: string
       target-branch:
         required: true
         type: string
@@ -24,7 +27,7 @@ jobs:
 
     env:
       TARGET_BRANCH: ${{ inputs.target-branch }}
-      SOURCE_BRANCH: ${{ github.ref_name }}
+      SOURCE_BRANCH: ${{ inputs.source-branch || github.ref_name }}
       AUTO_BUILD: ${{ inputs.auto_build }}
 
     steps:
@@ -41,7 +44,7 @@ jobs:
       - name: Checkout source branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ inputs.source-branch || github.ref_name }}
           fetch-depth: 0
           fetch-tags: true
           token: ${{ steps.app-token.outputs.token }}
@@ -51,17 +54,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Validate stable release source
-        if: inputs.target-branch == 'release'
-        run: |
-          if [ "${SOURCE_BRANCH}" != "${{ github.event.repository.default_branch }}" ]; then
-            echo "::error::Stable releases must be created from ${{ github.event.repository.default_branch }}, not ${SOURCE_BRANCH}."
-            exit 1
-          fi
-
       - name: Merge source into target branch
         run: |
           set -e
+          if [ -z "${SOURCE_BRANCH}" ] || [ -z "${TARGET_BRANCH}" ]; then
+            echo "Source and target branch must be set."
+            exit 1
+          fi
+          if [ "${SOURCE_BRANCH}" = "${TARGET_BRANCH}" ]; then
+            echo "Source and target branch must be different."
+            exit 1
+          fi
           git fetch origin "${SOURCE_BRANCH}" --tags
 
           if git ls-remote --exit-code --heads origin "${TARGET_BRANCH}" > /dev/null 2>&1; then
@@ -84,6 +87,6 @@ jobs:
         run: |
           echo "### Merged into \`${{ inputs.target-branch }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Source: \`${{ github.ref_name }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Source: \`${SOURCE_BRANCH}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**release.yml** runs on push to \`${{ inputs.target-branch }}\`." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           if git ls-remote --exit-code --heads origin release > /dev/null 2>&1; then
             git fetch origin release --tags
-            git merge --no-edit -s ours origin/release
+            git merge --no-edit --no-ff -s ours origin/release
           fi
 
       - name: Run semantic-release

--- a/documentation/Releasing.md
+++ b/documentation/Releasing.md
@@ -6,10 +6,10 @@ Releases are automatically created using semantic versioning when code is merged
 
 **Process:**
 1. Merge your changes to `master` using [conventional commit](#commit-messages) prefixes in PR titles.
-2. Run the **🧪 Create prerelease** action from `master`. It merges `master` into the `prerelease` branch and triggers semantic-release, which creates a GitHub Pre-Release and attaches the built plugin ZIP (`onoffice-for-wp-websites.zip`).
+2. Run the **🧪 Create prerelease** action. By default it merges `master` into the `prerelease` branch and triggers semantic-release, which creates a GitHub Pre-Release and attaches the built plugin ZIP (`onoffice-for-wp-websites.zip`).
    - **Auto Build option:** When triggering the prerelease action, you can enable the `Beta-Image nach Deploy automatisch bauen?` checkbox. This is forwarded for future beta hosting deploys.
-3. Test the prerelease. If something is wrong, fix it in a feature branch, merge to `master`, and create a new prerelease.
-4. Run the **🚀 Create release** action from `master`. It merges `master` into the `release` branch and triggers semantic-release to create the final release.
+3. Test the prerelease. If something is wrong, fix it in a feature branch, merge to the selected source branch, and create a new prerelease.
+4. Run the **🚀 Create release** action. By default it merges `prerelease` into the `release` branch; `master` or another source branch can still be selected. It triggers semantic-release to create the final release.
 5. On published final release, the update server deploy runs automatically and distributes `release.zip`.
 
 **What happens automatically on release:**
@@ -17,6 +17,8 @@ Releases are automatically created using semantic versioning when code is merged
 - On final releases only: the `== Changelog ==` section in `readme.txt` is updated from the generated release notes
 - Plugin ZIP is built and attached to the GitHub Release
 - Version changes are committed back to the release branch and synced to `master`
+
+The release actions are merge helpers only. Manual pushes or merges into `prerelease` or `release` also trigger the release workflow.
 
 **Changelog:** Do not edit `readme.txt` changelog manually. Write clear conventional commit messages — they become both the GitHub release notes and the WordPress changelog. Prereleases do not update `readme.txt` changelog; only final releases do.
 


### PR DESCRIPTION
## Summary
- add selectable source branches for release helper workflows
- default final releases to use the prerelease branch
- keep release helper merge commits so release workflow triggers reliably