### PR TITLE
fix: hide price on request text for empty or zero price fields

### DIFF
--- a/plugin/EstateList.php
+++ b/plugin/EstateList.php
@@ -1117,10 +1117,8 @@ class EstateList
 		if ($this->hasPriceOnRequestField() && ($recordRaw['preisAufAnfrage'] ?? null) === DataListView::SHOW_PRICE_ON_REQUEST) {
 			if ($this->enableShowPriceOnRequestText()) {
 				$priceFields = $this->_pDataView->getListFieldsShowPriceOnRequest();
-
 				foreach ($priceFields as $priceField) {
-					$rawPrice = $recordRaw[$priceField] ?? null;
-					$this->displayTextPriceOnRequest($recordModified, $priceField, $rawPrice);
+					$this->displayTextPriceOnRequest($recordModified, $priceField);
 				}
 				$this->_totalCostsData = [];
 			}
@@ -1156,10 +1154,13 @@ class EstateList
 	 * @param ArrayContainerEscape $recordModified
 	 * @param string $field
 	 */
-	private function displayTextPriceOnRequest($recordModified, $field, $rawPrice)
+	private function displayTextPriceOnRequest($recordModified, $field)
 	{
-		// Skip if the field is empty, raw value contains text (e.g., 'auf Anfrage'), or is a zero value (e.g., 0.00)
-		if (empty($recordModified[$field]) || !is_numeric($rawPrice) || (float)$rawPrice === 0.0) {
+		if (empty($recordModified[$field])) {
+			return;
+		}
+		$digitsOnly = preg_replace('/[^0-9]/', '', $recordModified[$field]);
+		if (intval($digitsOnly) === 0) {
 			return;
 		}
 		$recordModified[$field] = esc_html__('Price on request', 'onoffice-for-wp-websites');

--- a/plugin/EstateList.php
+++ b/plugin/EstateList.php
@@ -1119,7 +1119,8 @@ class EstateList
 				$priceFields = $this->_pDataView->getListFieldsShowPriceOnRequest();
 
 				foreach ($priceFields as $priceField) {
-					$this->displayTextPriceOnRequest($recordModified, $priceField);
+					$rawPrice = $recordRaw[$priceField] ?? null;
+					$this->displayTextPriceOnRequest($recordModified, $priceField, $rawPrice);
 				}
 				$this->_totalCostsData = [];
 			}
@@ -1155,11 +1156,13 @@ class EstateList
 	 * @param ArrayContainerEscape $recordModified
 	 * @param string $field
 	 */
-	private function displayTextPriceOnRequest($recordModified, $field)
+	private function displayTextPriceOnRequest($recordModified, $field, $rawPrice)
 	{
-		if (!empty($recordModified[$field])) {
-			$recordModified[$field] = esc_html__('Price on request', 'onoffice-for-wp-websites');
+		// Skip if the field is empty, raw value contains text (e.g., 'auf Anfrage'), or is a zero value (e.g., 0.00)
+		if (empty($recordModified[$field]) || !is_numeric($rawPrice) || (float)$rawPrice === 0.0) {
+			return;
 		}
+		$recordModified[$field] = esc_html__('Price on request', 'onoffice-for-wp-websites');
 	}
 
 	/**

--- a/plugin/EstateList.php
+++ b/plugin/EstateList.php
@@ -364,6 +364,9 @@ class EstateList
 
 		$estateParametersRaw['data'] = array_unique($estateParametersRaw['data']);
 
+		unset($estateParametersRaw['listname']);
+		unset($estateParametersRaw['params_list_cache']);
+
 		$pApiClientActionRawValues = clone $this->_pApiClientAction;
 		$pApiClientActionRawValues->setParameters($estateParametersRaw);
 		$pApiClientActionRawValues->addRequestToQueue()->sendRequests();


### PR DESCRIPTION
1. Ich habe die Abfrage zum Anzeigen auf Anfrage erweitertet, dass auch Felder wie Warmmiete, die bei DreamCasa zum Beispiel mit '0.00' gefüllt waren, als leer interpretiert werden.

2. Wir hatten ein Caching-Problem, dass Preis auf Anfrage teilweise nicht gesetzt wurde und damit die Klarpreise, trotz richtiger Einstellung im Frontend ausgegeben wurden.
Im letzte Release wurden Abfragen ergänzt, ob das Feld preisAufAnfrage überhaupt aktiv ist in enterprise.
Mit der Bereinigung von `if ($this->enableShowPriceOnRequestText() && $this->hasPriceOnRequestField() && !in_array('preisAufAnfrage', $requestParams['data'], true)) {
   $requestParams['data'][] = 'preisAufAnfrage';
}` (im letzten Release)
wurde der Cache Fehler sichtbar, weil nun nicht mehr stumpf immer preisAufAnfrage angehängt wurde.
Das Cache Collapsing habe ich mit 
`unset($estateParametersRaw['listname']);
unset($estateParametersRaw['params_list_cache']);`
behoben.