### PR TITLE
fix(P#168033): Geo Filter

### DIFF
--- a/SDK/src/internal/ApiCall.php
+++ b/SDK/src/internal/ApiCall.php
@@ -373,7 +373,6 @@ class ApiCall
 
 	/**
 	 * Apply client-side geo filtering to fresh list responses after cache writing.
-	 * Fresh API responses are already paginated by the API, so keep that slice.
 	 *
 	 * @param Request[] $actionParametersOrder
 	 */
@@ -403,7 +402,7 @@ class ApiCall
 
 			$pResponse = $this->_responses[$requestId];
 			$params['listoffset'] = 0;
-			$params['listlimit'] = PHP_INT_MAX;
+			$params['listlimit'] = 500;
 			$this->_responses[$requestId] = new Response(
 				$pRequest,
 				$this->applyListCacheFiltering($pResponse->getResponseData(), $params)

--- a/SDK/src/internal/ApiCall.php
+++ b/SDK/src/internal/ApiCall.php
@@ -839,6 +839,7 @@ class ApiCall
 			$cachedResponse["data"]["records"] = $filteredArray;
 			$cachedResponse["raw"]["data"]["records"] = $filteredArrayRaw;
 			$filteredArray = $this->sortRecords($cachedResponse, $filter, 'geo_distance', 'ASC');
+			$filteredArray = array_slice($filteredArray, 0, $isGeoAndMax);
 		}
 		$cachedResponse["data"]["records"] = $filteredArray;
 		$cachedResponse["raw"]["data"]["records"] = $filteredArrayRaw;

--- a/SDK/src/internal/ApiCall.php
+++ b/SDK/src/internal/ApiCall.php
@@ -121,6 +121,7 @@ class ApiCall
 		{
 			return;
 		}
+
 		foreach ($actionParameters as $key => $action) {
 			if (isset($action['parameters']['filter']['geo'])) {
 				unset($actionParameters[$key]['parameters']['filter']['geo']);
@@ -129,6 +130,7 @@ class ApiCall
 				unset($actionParameters[$key]['parameters']['params_list_cache']['filter']['geo']);
 			}
 		}
+
 		$responseHttp = $this->getFromHttp($token, $actionParameters, $httpFetch);
 
 		$result = json_decode($responseHttp, true);
@@ -282,6 +284,7 @@ class ApiCall
 		}
 
 		$this->sendHttpRequests($token, $actionParameters, $actionParametersOrder, $httpFetch, $saveToCache);
+		$this->applyFreshGeoFiltering($actionParametersOrder);
 
 		// Reuse source results for duplicate requests that were queued in the same send cycle.
 		foreach ($duplicateRequestsBySourceRequestId as $sourceRequestId => $duplicateRequests)
@@ -342,15 +345,13 @@ class ApiCall
 			$filter = (isset($params["filter"]) && is_array($params["filter"]))
 				? $params["filter"]
 				: [];
+			$hasGeoFilter = isset($filter['geo'][0]['loc']);
 
-			if (
-				!isset($cachedResponse["data"]["records"]) ||
-				!is_array($cachedResponse["data"]["records"]) ||
-				!isset($cachedResponse["raw"]["data"]["records"]) ||
-				!is_array($cachedResponse["raw"]["data"]["records"]) ||
-				!isset($cachedResponse["types"]) ||
-				!is_array($cachedResponse["types"])
-			) {
+			if (!$hasGeoFilter && !$this->hasCompleteFilterableResponseShape($cachedResponse)) {
+				return $cachedResponse;
+			}
+
+			if (!$this->ensureFilterableResponseShape($cachedResponse)) {
 				return $cachedResponse;
 			}
 
@@ -363,6 +364,93 @@ class ApiCall
 				$this->recordsPerPage($cachedResponse["data"]["records"], intval($params["listlimit"] ?? 20), intval($params["listoffset"] ?? 0));
 		}
 		return $cachedResponse;
+	}
+
+	/**
+	 * Apply client-side geo filtering to fresh list responses after cache writing.
+	 * Fresh API responses are already paginated by the API, so this intentionally
+	 * only filters/sorts the returned page and does not re-apply pagination.
+	 *
+	 * @param Request[] $actionParametersOrder
+	 */
+	private function applyFreshGeoFiltering(array $actionParametersOrder): void
+	{
+		foreach ($actionParametersOrder as $pRequest)
+		{
+			$requestId = $pRequest->getRequestId();
+			if (!isset($this->_responses[$requestId])) {
+				continue;
+			}
+
+			$usedParams = $this->normalizeFieldDependencyParameters(
+				$pRequest->getApiAction()->getActionParameters()
+			);
+			$params = $usedParams['parameters'] ?? [];
+			$geoFilter = $params['filter']['geo'][0] ?? null;
+
+			if (
+				!isset($params['listname']) ||
+				($params['formatoutput'] ?? false) != true ||
+				!is_array($geoFilter) ||
+				empty($geoFilter['loc'])
+			) {
+				continue;
+			}
+
+			$pResponse = $this->_responses[$requestId];
+			$responseData = $pResponse->getResponseData();
+			if (!$this->ensureFilterableResponseShape($responseData)) {
+				continue;
+			}
+
+			$filter = ['geo' => [$geoFilter]];
+			$this->filterRecords($responseData, $filter);
+			$responseData['data']['records'] = $this->sortRecords($responseData, $filter, 'geo_distance', 'ASC');
+			$responseData['data']['meta']['cntabsolute'] = count($responseData['data']['records']);
+
+			$this->_responses[$requestId] = new Response($pRequest, $responseData);
+		}
+	}
+
+	private function ensureFilterableResponseShape(array &$response): bool
+	{
+		if (
+			!isset($response['data']['records']) ||
+			!is_array($response['data']['records'])
+		) {
+			return false;
+		}
+
+		if (!isset($response['raw']) || !is_array($response['raw'])) {
+			$response['raw'] = [];
+		}
+		if (!isset($response['raw']['data']) || !is_array($response['raw']['data'])) {
+			$response['raw']['data'] = [];
+		}
+		if (!isset($response['raw']['data']['records']) || !is_array($response['raw']['data']['records'])) {
+			$response['raw']['data']['records'] = [];
+			foreach ($response['data']['records'] as $record) {
+				$response['raw']['data']['records'][] = [
+					'id' => $record['id'] ?? 0,
+					'elements' => $record['elements'] ?? [],
+				];
+			}
+		}
+		if (!isset($response['types']) || !is_array($response['types'])) {
+			$response['types'] = [];
+		}
+
+		return true;
+	}
+
+	private function hasCompleteFilterableResponseShape(array $response): bool
+	{
+		return isset($response['data']['records']) &&
+			is_array($response['data']['records']) &&
+			isset($response['raw']['data']['records']) &&
+			is_array($response['raw']['data']['records']) &&
+			isset($response['types']) &&
+			is_array($response['types']);
 	}
 
 	/**
@@ -542,14 +630,7 @@ class ApiCall
 
 	private function filterRecords(array &$cachedResponse, array $filter)
 	{
-		if (
-			!isset($cachedResponse["data"]["records"]) ||
-			!is_array($cachedResponse["data"]["records"]) ||
-			!isset($cachedResponse["raw"]["data"]["records"]) ||
-			!is_array($cachedResponse["raw"]["data"]["records"]) ||
-			!isset($cachedResponse["types"]) ||
-			!is_array($cachedResponse["types"])
-		) {
+		if (!$this->ensureFilterableResponseShape($cachedResponse)) {
 			return;
 		}
 
@@ -754,8 +835,8 @@ class ApiCall
 						$longitude = floatval($selectedCoordinates[0]);
 						$latitude = floatval($selectedCoordinates[1]);
 
-						$coordinate1 = new Coordinate($item["elements"]['laengengrad'], $item["elements"]['breitengrad']);
-						$coordinate2 = new Coordinate($longitude, $latitude);
+						$coordinate1 = new Coordinate((float)$item["elements"]['breitengrad'], (float)$item["elements"]['laengengrad']);
+						$coordinate2 = new Coordinate($latitude, $longitude);
 						$distance = $calculator->getDistance($coordinate1, $coordinate2);
 
 						if(intval($distance/1000) > $km){

--- a/SDK/src/internal/ApiCall.php
+++ b/SDK/src/internal/ApiCall.php
@@ -347,11 +347,16 @@ class ApiCall
 				: [];
 			$hasGeoFilter = isset($filter['geo'][0]['loc']);
 
-			if (!$hasGeoFilter && !$this->hasCompleteFilterableResponseShape($cachedResponse)) {
-				return $cachedResponse;
-			}
-
-			if (!$this->ensureFilterableResponseShape($cachedResponse)) {
+			if (
+				!isset($cachedResponse["data"]["records"]) ||
+				!is_array($cachedResponse["data"]["records"]) ||
+				(!$hasGeoFilter && (
+					!isset($cachedResponse["raw"]["data"]["records"]) ||
+					!is_array($cachedResponse["raw"]["data"]["records"]) ||
+					!isset($cachedResponse["types"]) ||
+					!is_array($cachedResponse["types"])
+				))
+			) {
 				return $cachedResponse;
 			}
 
@@ -368,8 +373,7 @@ class ApiCall
 
 	/**
 	 * Apply client-side geo filtering to fresh list responses after cache writing.
-	 * Fresh API responses are already paginated by the API, so this intentionally
-	 * only filters/sorts the returned page and does not re-apply pagination.
+	 * Fresh API responses are already paginated by the API, so keep that slice.
 	 *
 	 * @param Request[] $actionParametersOrder
 	 */
@@ -398,59 +402,13 @@ class ApiCall
 			}
 
 			$pResponse = $this->_responses[$requestId];
-			$responseData = $pResponse->getResponseData();
-			if (!$this->ensureFilterableResponseShape($responseData)) {
-				continue;
-			}
-
-			$filter = ['geo' => [$geoFilter]];
-			$this->filterRecords($responseData, $filter);
-			$responseData['data']['records'] = $this->sortRecords($responseData, $filter, 'geo_distance', 'ASC');
-			$responseData['data']['meta']['cntabsolute'] = count($responseData['data']['records']);
-
-			$this->_responses[$requestId] = new Response($pRequest, $responseData);
+			$params['listoffset'] = 0;
+			$params['listlimit'] = PHP_INT_MAX;
+			$this->_responses[$requestId] = new Response(
+				$pRequest,
+				$this->applyListCacheFiltering($pResponse->getResponseData(), $params)
+			);
 		}
-	}
-
-	private function ensureFilterableResponseShape(array &$response): bool
-	{
-		if (
-			!isset($response['data']['records']) ||
-			!is_array($response['data']['records'])
-		) {
-			return false;
-		}
-
-		if (!isset($response['raw']) || !is_array($response['raw'])) {
-			$response['raw'] = [];
-		}
-		if (!isset($response['raw']['data']) || !is_array($response['raw']['data'])) {
-			$response['raw']['data'] = [];
-		}
-		if (!isset($response['raw']['data']['records']) || !is_array($response['raw']['data']['records'])) {
-			$response['raw']['data']['records'] = [];
-			foreach ($response['data']['records'] as $record) {
-				$response['raw']['data']['records'][] = [
-					'id' => $record['id'] ?? 0,
-					'elements' => $record['elements'] ?? [],
-				];
-			}
-		}
-		if (!isset($response['types']) || !is_array($response['types'])) {
-			$response['types'] = [];
-		}
-
-		return true;
-	}
-
-	private function hasCompleteFilterableResponseShape(array $response): bool
-	{
-		return isset($response['data']['records']) &&
-			is_array($response['data']['records']) &&
-			isset($response['raw']['data']['records']) &&
-			is_array($response['raw']['data']['records']) &&
-			isset($response['types']) &&
-			is_array($response['types']);
 	}
 
 	/**
@@ -630,8 +588,23 @@ class ApiCall
 
 	private function filterRecords(array &$cachedResponse, array $filter)
 	{
-		if (!$this->ensureFilterableResponseShape($cachedResponse)) {
+		if (
+			!isset($cachedResponse["data"]["records"]) ||
+			!is_array($cachedResponse["data"]["records"])
+		) {
 			return;
+		}
+		if (!isset($cachedResponse["raw"]["data"]["records"]) || !is_array($cachedResponse["raw"]["data"]["records"])) {
+			$cachedResponse["raw"]["data"]["records"] = [];
+			foreach ($cachedResponse["data"]["records"] as $record) {
+				$cachedResponse["raw"]["data"]["records"][] = [
+					"id" => $record["id"] ?? 0,
+					"elements" => $record["elements"] ?? [],
+				];
+			}
+		}
+		if (!isset($cachedResponse["types"]) || !is_array($cachedResponse["types"])) {
+			$cachedResponse["types"] = [];
 		}
 
 		$records = $cachedResponse["data"]["records"];
@@ -812,8 +785,8 @@ class ApiCall
 					elseif (strtolower($op) === 'geo')
 					{
 						$km = intval($val);
-						$min = $value[0]["min"];
-						$max = $value[0]["max"];
+						$min = $value[0]["min"] ?? null;
+						$max = $value[0]["max"] ?? null;
 
 						$loc = $value[0]["loc"] ?? '';
 						if(str_starts_with($loc, "0-")) {

--- a/SDK/src/internal/ApiCall.php
+++ b/SDK/src/internal/ApiCall.php
@@ -839,7 +839,6 @@ class ApiCall
 			$cachedResponse["data"]["records"] = $filteredArray;
 			$cachedResponse["raw"]["data"]["records"] = $filteredArrayRaw;
 			$filteredArray = $this->sortRecords($cachedResponse, $filter, 'geo_distance', 'ASC');
-			$filteredArray = array_slice($filteredArray, 0, $isGeoAndMax);
 		}
 		$cachedResponse["data"]["records"] = $filteredArray;
 		$cachedResponse["raw"]["data"]["records"] = $filteredArrayRaw;

--- a/SDK/tests/ApiCallTest.php
+++ b/SDK/tests/ApiCallTest.php
@@ -307,6 +307,52 @@ class ApiCallTest extends \PHPUnit\Framework\TestCase
 		$this->assertArrayHasKey('records', $result['data']);
 	}
 
+	/**
+	 * Geo max should cap the complete result before pagination is applied.
+	 */
+	public function testApplyListCacheFiltering_geoMaxCapsTotalBeforePagination()
+	{
+		$apiCall = new ApiCall();
+		$records = [];
+		for ($id = 1; $id <= 5; $id++) {
+			$records[] = [
+				'id' => $id,
+				'elements' => [
+					'laengengrad' => 7.0 + ($id / 1000),
+					'breitengrad' => 51.0,
+				],
+			];
+		}
+
+		$response = [
+			'data' => [
+				'meta' => ['cntabsolute' => 5],
+				'records' => $records,
+			],
+		];
+
+		$method = new ReflectionMethod(ApiCall::class, 'applyListCacheFiltering');
+		$method->setAccessible(true);
+
+		$params = [
+			'formatoutput' => true,
+			'filter' => ['geo' => [[
+				'op' => 'geo',
+				'val' => 200,
+				'loc' => '7.0,51.0',
+				'max' => 3,
+			]]],
+			'listlimit' => 2,
+			'listoffset' => 2,
+		];
+
+		$result = $method->invokeArgs($apiCall, [$response, $params]);
+
+		$this->assertEquals(3, $result['data']['meta']['cntabsolute']);
+		$this->assertCount(1, $result['data']['records']);
+		$this->assertEquals(3, $result['data']['records'][0]['id']);
+	}
+
 
 	/**
 	 * applyListCacheFiltering should early-return when no geo filter and raw/types missing.

--- a/SDK/tests/ApiCallTest.php
+++ b/SDK/tests/ApiCallTest.php
@@ -6,6 +6,7 @@ use onOffice\SDK\Cache\onOfficeSDKCache;
 use onOffice\SDK\Exception\HttpFetchNoResultException;
 use onOffice\SDK\internal\ApiCall;
 use onOffice\SDK\internal\HttpFetch;
+use ReflectionMethod;
 
 class ApiCallTest extends \PHPUnit\Framework\TestCase
 {
@@ -161,5 +162,183 @@ class ApiCallTest extends \PHPUnit\Framework\TestCase
 		$result = $apiCall->getErrors();
 
 		$this->assertEquals([], $result);
+	}
+
+
+	/**
+	 * filterRecords should auto-generate raw records and types when they are missing.
+	 */
+	public function testFilterRecords_generatesMissingRawAndTypes()
+	{
+		$apiCall = new ApiCall();
+		$response = [
+			'data' => [
+				'records' => [
+					[
+						'id' => 1,
+						'elements' => ['objektart' => 'haus'],
+					],
+				],
+			],
+		];
+
+		$method = new ReflectionMethod(ApiCall::class, 'filterRecords');
+		$method->setAccessible(true);
+		$method->invokeArgs($apiCall, [&$response, []]);
+
+		$this->assertArrayHasKey('raw', $response);
+		$this->assertArrayHasKey('data', $response['raw']);
+		$this->assertArrayHasKey('records', $response['raw']['data']);
+		$this->assertCount(1, $response['raw']['data']['records']);
+		$this->assertEquals(1, $response['raw']['data']['records'][0]['id']);
+		$this->assertArrayHasKey('types', $response);
+		$this->assertIsArray($response['types']);
+	}
+
+
+	/**
+	 * filterRecords should not crash when geo filter has no min/max keys.
+	 */
+	public function testFilterRecords_geoFilterNullSafeMinMax()
+	{
+		$apiCall = new ApiCall();
+		$response = [
+			'data' => [
+				'records' => [
+					[
+						'id' => 1,
+						'elements' => ['laengengrad' => 7.0, 'breitengrad' => 51.0],
+					],
+				],
+			],
+			'raw' => [
+				'data' => [
+					'records' => [
+						['id' => 1, 'elements' => ['laengengrad' => 7.0, 'breitengrad' => 51.0]],
+					],
+				],
+			],
+			'types' => [],
+		];
+
+		$method = new ReflectionMethod(ApiCall::class, 'filterRecords');
+		$method->setAccessible(true);
+
+		$filter = ['geo' => [['op' => 'geo', 'val' => 10, 'loc' => '7.0,51.0']]];
+		$method->invokeArgs($apiCall, [&$response, $filter]);
+
+		$this->assertCount(1, $response['data']['records']);
+	}
+
+
+	/**
+	 * filterRecords should filter out records beyond the geo radius.
+	 */
+	public function testFilterRecords_geoFilterRemovesDistantRecords()
+	{
+		$apiCall = new ApiCall();
+		$response = [
+			'data' => [
+				'records' => [
+					[
+						'id' => 1,
+						'elements' => ['laengengrad' => 7.0, 'breitengrad' => 51.0],
+					],
+					[
+						'id' => 2,
+						'elements' => ['laengengrad' => 13.4, 'breitengrad' => 52.5],
+					],
+				],
+			],
+			'raw' => [
+				'data' => [
+					'records' => [
+						['id' => 1, 'elements' => ['laengengrad' => 7.0, 'breitengrad' => 51.0]],
+						['id' => 2, 'elements' => ['laengengrad' => 13.4, 'breitengrad' => 52.5]],
+					],
+				],
+			],
+			'types' => [],
+		];
+
+		$method = new ReflectionMethod(ApiCall::class, 'filterRecords');
+		$method->setAccessible(true);
+
+		$filter = ['geo' => [['op' => 'geo', 'val' => 1, 'loc' => '7.0,51.0']]];
+		$method->invokeArgs($apiCall, [&$response, $filter]);
+
+		$this->assertCount(1, $response['data']['records']);
+		$this->assertEquals(1, $response['data']['records'][0]['id']);
+		$this->assertArrayHasKey('geo_distance', $response['data']['records'][0]['elements']);
+	}
+
+
+	/**
+	 * applyListCacheFiltering should not require raw/types when geo filter is present.
+	 */
+	public function testApplyListCacheFiltering_geoFilterBypassesRawTypesCheck()
+	{
+		$apiCall = new ApiCall();
+		$response = [
+			'data' => [
+				'meta' => ['cntabsolute' => 1],
+				'records' => [
+					[
+						'id' => 1,
+						'elements' => ['laengengrad' => 7.0, 'breitengrad' => 51.0, 'kaufpreis' => 100000],
+					],
+				],
+			],
+		];
+
+		$method = new ReflectionMethod(ApiCall::class, 'applyListCacheFiltering');
+		$method->setAccessible(true);
+
+		$params = [
+			'formatoutput' => true,
+			'filter' => ['geo' => [['op' => 'geo', 'val' => 10, 'loc' => '7.0,51.0']]],
+			'listlimit' => 20,
+			'listoffset' => 0,
+		];
+
+		$result = $method->invokeArgs($apiCall, [$response, $params]);
+
+		$this->assertArrayHasKey('data', $result);
+		$this->assertArrayHasKey('records', $result['data']);
+	}
+
+
+	/**
+	 * applyListCacheFiltering should early-return when no geo filter and raw/types missing.
+	 */
+	public function testApplyListCacheFiltering_withoutGeoFilterRequiresRawTypes()
+	{
+		$apiCall = new ApiCall();
+		$response = [
+			'data' => [
+				'meta' => ['cntabsolute' => 1],
+				'records' => [
+					[
+						'id' => 1,
+						'elements' => ['kaufpreis' => 100000],
+					],
+				],
+			],
+		];
+
+		$method = new ReflectionMethod(ApiCall::class, 'applyListCacheFiltering');
+		$method->setAccessible(true);
+
+		$params = [
+			'formatoutput' => true,
+			'filter' => ['kaufpreis' => [['op' => '=', 'val' => 100000]]],
+			'listlimit' => 20,
+			'listoffset' => 0,
+		];
+
+		$originalResponse = $response;
+		$result = $method->invokeArgs($apiCall, [$response, $params]);
+
+		$this->assertEquals($originalResponse, $result);
 	}
 }

--- a/plugin/AddressList.php
+++ b/plugin/AddressList.php
@@ -49,8 +49,6 @@ use onOffice\WPlugin\DataView\DataAddressDetailView;
 use onOffice\WPlugin\Controller\AddressDetailUrl;
 use onOffice\WPlugin\Filter\EstateFilterBuilderDetailViewAddress;
 use onOffice\WPlugin\ViewFieldModifier\AddressViewFieldModifierTypes;
-use Location\Distance\Vincenty;
-use Location\Coordinate;
 
 /**
  *
@@ -158,9 +156,6 @@ implements AddressListBase
 
 	/** @var AddressDetailUrl */
 	private $_pLanguageSwitcher;
-
-	/** @var int|null */
-	private $_geoFilteredCount = null;
 
 	/**
 	 *
@@ -270,15 +265,14 @@ implements AddressListBase
 			$offset = ( $currentPage - 1 ) * $numRecordsPerPage;
 		}
 
-		$hasGeoSearch = false;
-
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Geo search is a public filter, no nonce needed
 		if ( isset( $_GET['geo_search'] ) ) {
 			$geoSearch = sanitize_text_field( wp_unslash( $_GET['geo_search'] ) );
 			$geoCoords = explode( ',', $geoSearch );
 			if ( count( $geoCoords ) === 2 ) {
+				$filter['geo'][0]['op'] = $filter['geo'][0]['op'] ?? 'geo';
+				$filter['geo'][0]['val'] = $filter['geo'][0]['val'] ?? 200;
 				$filter['geo'][0]['loc'] = $geoSearch;
-				$hasGeoSearch = true;
 			}
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
@@ -296,9 +290,7 @@ implements AddressListBase
 		);
 
 		if ($this->_pDataViewAddress instanceof DataListViewAddress) {
-			if (!$hasGeoSearch) {
-				$parameters['params_list_cache'] = $this->getAddressListParametersForCache($formatOutput, $language);
-			}
+			$parameters['params_list_cache'] = $this->getAddressListParametersForCache($formatOutput, $language);
 			$parameters = array('listname' => $this->_pDataViewAddress->getName()) + $parameters;
 		}
 
@@ -375,35 +367,6 @@ implements AddressListBase
 		$result = $this->_pApiClientAction->getResult();
 		$this->_records = $result["data"]["records"];
 
-		// Apply geo distance filter (client-side; API does not support geo operator)
-		$geoFilter = $parameters['filter']['geo'][0] ?? null;
-		if ($geoFilter && !empty($geoFilter['loc'])) {
-			$locParts = explode(',', $geoFilter['loc']);
-			if (count($locParts) === 2) {
-				$refLng = (float) trim($locParts[0]);
-				$refLat = (float) trim($locParts[1]);
-				$radiusKm = (float) ($geoFilter['val'] ?? 200);
-				$radius = $radiusKm * 1000;
-				$refCoord = new Coordinate($refLat, $refLng);
-				$vincenty = new Vincenty();
-				$filtered = [];
-				foreach ($this->_records as $rec) {
-					$elements = $rec['elements'] ?? [];
-					$lng = $elements['laengengrad'] ?? null;
-					$lat = $elements['breitengrad'] ?? null;
-					if ($lng !== null && $lat !== null) {
-						$coord = new Coordinate((float) $lat, (float) $lng);
-						$dist = $vincenty->getDistance($refCoord, $coord);
-						if ($dist <= $radius) {
-							$filtered[] = $rec;
-						}
-					}
-				}
-				$this->_geoFilteredCount = count($filtered);
-				$this->_records = $filtered;
-			}
-		}
-
 		$recordsRaw = $pApiClientActionRaw->getResultRecords();
 
 		$this->fetchEstatesForAddressIds($this->getAddressIds());
@@ -411,9 +374,6 @@ implements AddressListBase
 		$this->_recordsRaw = array_combine(array_column($recordsRaw, 'id'), $recordsRaw);
 
 		$resultMeta = $this->_pApiClientAction->getResultMeta();
-		if ($this->_geoFilteredCount !== null) {
-			$resultMeta['cntabsolute'] = $this->_geoFilteredCount;
-		}
 		$numpages = ceil($resultMeta['cntabsolute']/$this->_pDataViewAddress->getRecordsPerPage());
 
 		$multipage = $numpages > 1;
@@ -589,9 +549,6 @@ implements AddressListBase
 	 */
 	public function getAddressOverallCount()
 	{
-		if ($this->_geoFilteredCount !== null) {
-			return $this->_geoFilteredCount;
-		}
 		return $this->_pApiClientAction->getResultMeta()['cntabsolute'];
 	}
 

--- a/plugin/AddressList.php
+++ b/plugin/AddressList.php
@@ -364,25 +364,6 @@ implements AddressListBase
 		$parameters = $this->getAddressParameters($newPage, true);
 		$parametersRaw = $this->getAddressParameters($newPage, false);
 
-		// Detect active geo filter before modifying parameters
-		$geoKm = 0;
-		$geoLoc = null;
-		$filter = $parameters['filter'] ?? [];
-		if (isset($filter['geo'][0]['loc'])) {
-			$geoKm = intval($filter['geo'][0]['val'] ?? 0);
-			$geoLoc = $filter['geo'][0]['loc'] ?? null;
-		}
-
-		// When geo search is active, fetch ALL records (large limit) so client-side
-		// distance filtering covers the full dataset, not just the current page.
-		$geoAllRecords = null;
-		if ($geoKm > 0 && $geoLoc !== null) {
-			$parameters['listlimit'] = 10000;
-			$parameters['listoffset'] = 0;
-			$parametersRaw['listlimit'] = 10000;
-			$parametersRaw['listoffset'] = 0;
-		}
-
 		$this->_pApiClientAction->setParameters($parameters);
 		$this->_pApiClientAction->addRequestToQueue();
 
@@ -393,58 +374,47 @@ implements AddressListBase
 		$pSDKWrapper->sendRequests();
 		$result = $this->_pApiClientAction->getResult();
 		$this->_records = $result["data"]["records"];
-		$recordsRaw = $pApiClientActionRaw->getResultRecords();
 
-		// Apply client-side geo filter
-		if ($geoKm > 0 && $geoLoc !== null) {
-			$locCoords = explode(',', $geoLoc);
-			if (count($locCoords) === 2) {
-				$searchLng = floatval($locCoords[0]);
-				$searchLat = floatval($locCoords[1]);
-				$searchCoord = new Coordinate($searchLat, $searchLng);
-				$calculator = new Vincenty();
+		// Apply geo distance filter (client-side; API does not support geo operator)
+		$geoFilter = $parameters['filter']['geo'][0] ?? null;
+		if ($geoFilter && !empty($geoFilter['loc'])) {
+			$locParts = explode(',', $geoFilter['loc']);
+			if (count($locParts) === 2) {
+				$refLng = (float) trim($locParts[0]);
+				$refLat = (float) trim($locParts[1]);
+				$radiusKm = (float) ($geoFilter['val'] ?? 200);
+				$radius = $radiusKm * 1000;
+				$refCoord = new Coordinate($refLat, $refLng);
+				$vincenty = new Vincenty();
 				$filtered = [];
 				foreach ($this->_records as $rec) {
-					$el = $rec['elements'] ?? [];
-					$lng = $el['laengengrad'] ?? null;
-					$lat = $el['breitengrad'] ?? null;
-					if ($lng === null || $lat === null) {
-						continue;
-					}
-					$recCoord = new Coordinate(floatval($lat), floatval($lng));
-					$distance = $calculator->getDistance($searchCoord, $recCoord);
-					if (intval($distance / 1000) <= $geoKm) {
-						$el['geo_distance'] = intval($distance);
-						$rec['elements'] = $el;
-						$filtered[] = $rec;
+					$elements = $rec['elements'] ?? [];
+					$lng = $elements['laengengrad'] ?? null;
+					$lat = $elements['breitengrad'] ?? null;
+					if ($lng !== null && $lat !== null) {
+						$coord = new Coordinate((float) $lat, (float) $lng);
+						$dist = $vincenty->getDistance($refCoord, $coord);
+						if ($dist <= $radius) {
+							$filtered[] = $rec;
+						}
 					}
 				}
-				$this->_records = $filtered;
 				$this->_geoFilteredCount = count($filtered);
-				$result['data']['meta']['cntabsolute'] = $this->_geoFilteredCount;
+				$this->_records = $filtered;
 			}
 		}
 
-
+		$recordsRaw = $pApiClientActionRaw->getResultRecords();
 
 		$this->fetchEstatesForAddressIds($this->getAddressIds());
 		$this->fillAddressesById($this->_records);
-
-		// Re-apply offset/limit pagination if geo filter expanded to all records
-		if ($geoKm > 0 && $geoLoc !== null) {
-			$offset = ($newPage - 1) * $this->_pDataViewAddress->getRecordsPerPage();
-			$this->_records = array_slice($this->_records, $offset, $this->_pDataViewAddress->getRecordsPerPage());
-		}
-
-		// Filter raw records to match filtered _records
-		$filteredIds = array_column($this->_records, 'id');
-		$recordsRaw = array_values(array_filter($recordsRaw, function($r) use ($filteredIds) {
-			return in_array($r['id'], $filteredIds);
-		}));
 		$this->_recordsRaw = array_combine(array_column($recordsRaw, 'id'), $recordsRaw);
 
-		$cntabsolute = $this->getAddressOverallCount();
-		$numpages = ceil($cntabsolute/$this->_pDataViewAddress->getRecordsPerPage());
+		$resultMeta = $this->_pApiClientAction->getResultMeta();
+		if ($this->_geoFilteredCount !== null) {
+			$resultMeta['cntabsolute'] = $this->_geoFilteredCount;
+		}
+		$numpages = ceil($resultMeta['cntabsolute']/$this->_pDataViewAddress->getRecordsPerPage());
 
 		$multipage = $numpages > 1;
 		$more = true;

--- a/plugin/AddressList.php
+++ b/plugin/AddressList.php
@@ -49,6 +49,8 @@ use onOffice\WPlugin\DataView\DataAddressDetailView;
 use onOffice\WPlugin\Controller\AddressDetailUrl;
 use onOffice\WPlugin\Filter\EstateFilterBuilderDetailViewAddress;
 use onOffice\WPlugin\ViewFieldModifier\AddressViewFieldModifierTypes;
+use Location\Distance\Vincenty;
+use Location\Coordinate;
 
 /**
  *
@@ -156,6 +158,9 @@ implements AddressListBase
 
 	/** @var AddressDetailUrl */
 	private $_pLanguageSwitcher;
+
+	/** @var int|null */
+	private $_geoFilteredCount = null;
 
 	/**
 	 *
@@ -265,12 +270,15 @@ implements AddressListBase
 			$offset = ( $currentPage - 1 ) * $numRecordsPerPage;
 		}
 
+		$hasGeoSearch = false;
+
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Geo search is a public filter, no nonce needed
 		if ( isset( $_GET['geo_search'] ) ) {
 			$geoSearch = sanitize_text_field( wp_unslash( $_GET['geo_search'] ) );
 			$geoCoords = explode( ',', $geoSearch );
 			if ( count( $geoCoords ) === 2 ) {
 				$filter['geo'][0]['loc'] = $geoSearch;
+				$hasGeoSearch = true;
 			}
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
@@ -288,7 +296,9 @@ implements AddressListBase
 		);
 
 		if ($this->_pDataViewAddress instanceof DataListViewAddress) {
-			$parameters['params_list_cache'] = $this->getAddressListParametersForCache($formatOutput, $language);
+			if (!$hasGeoSearch) {
+				$parameters['params_list_cache'] = $this->getAddressListParametersForCache($formatOutput, $language);
+			}
 			$parameters = array('listname' => $this->_pDataViewAddress->getName()) + $parameters;
 		}
 
@@ -354,6 +364,25 @@ implements AddressListBase
 		$parameters = $this->getAddressParameters($newPage, true);
 		$parametersRaw = $this->getAddressParameters($newPage, false);
 
+		// Detect active geo filter before modifying parameters
+		$geoKm = 0;
+		$geoLoc = null;
+		$filter = $parameters['filter'] ?? [];
+		if (isset($filter['geo'][0]['loc'])) {
+			$geoKm = intval($filter['geo'][0]['val'] ?? 0);
+			$geoLoc = $filter['geo'][0]['loc'] ?? null;
+		}
+
+		// When geo search is active, fetch ALL records (large limit) so client-side
+		// distance filtering covers the full dataset, not just the current page.
+		$geoAllRecords = null;
+		if ($geoKm > 0 && $geoLoc !== null) {
+			$parameters['listlimit'] = 10000;
+			$parameters['listoffset'] = 0;
+			$parametersRaw['listlimit'] = 10000;
+			$parametersRaw['listoffset'] = 0;
+		}
+
 		$this->_pApiClientAction->setParameters($parameters);
 		$this->_pApiClientAction->addRequestToQueue();
 
@@ -366,12 +395,56 @@ implements AddressListBase
 		$this->_records = $result["data"]["records"];
 		$recordsRaw = $pApiClientActionRaw->getResultRecords();
 
+		// Apply client-side geo filter
+		if ($geoKm > 0 && $geoLoc !== null) {
+			$locCoords = explode(',', $geoLoc);
+			if (count($locCoords) === 2) {
+				$searchLng = floatval($locCoords[0]);
+				$searchLat = floatval($locCoords[1]);
+				$searchCoord = new Coordinate($searchLat, $searchLng);
+				$calculator = new Vincenty();
+				$filtered = [];
+				foreach ($this->_records as $rec) {
+					$el = $rec['elements'] ?? [];
+					$lng = $el['laengengrad'] ?? null;
+					$lat = $el['breitengrad'] ?? null;
+					if ($lng === null || $lat === null) {
+						continue;
+					}
+					$recCoord = new Coordinate(floatval($lat), floatval($lng));
+					$distance = $calculator->getDistance($searchCoord, $recCoord);
+					if (intval($distance / 1000) <= $geoKm) {
+						$el['geo_distance'] = intval($distance);
+						$rec['elements'] = $el;
+						$filtered[] = $rec;
+					}
+				}
+				$this->_records = $filtered;
+				$this->_geoFilteredCount = count($filtered);
+				$result['data']['meta']['cntabsolute'] = $this->_geoFilteredCount;
+			}
+		}
+
+
+
 		$this->fetchEstatesForAddressIds($this->getAddressIds());
 		$this->fillAddressesById($this->_records);
+
+		// Re-apply offset/limit pagination if geo filter expanded to all records
+		if ($geoKm > 0 && $geoLoc !== null) {
+			$offset = ($newPage - 1) * $this->_pDataViewAddress->getRecordsPerPage();
+			$this->_records = array_slice($this->_records, $offset, $this->_pDataViewAddress->getRecordsPerPage());
+		}
+
+		// Filter raw records to match filtered _records
+		$filteredIds = array_column($this->_records, 'id');
+		$recordsRaw = array_values(array_filter($recordsRaw, function($r) use ($filteredIds) {
+			return in_array($r['id'], $filteredIds);
+		}));
 		$this->_recordsRaw = array_combine(array_column($recordsRaw, 'id'), $recordsRaw);
 
-		$resultMeta = $this->_pApiClientAction->getResultMeta();
-		$numpages = ceil($resultMeta['cntabsolute']/$this->_pDataViewAddress->getRecordsPerPage());
+		$cntabsolute = $this->getAddressOverallCount();
+		$numpages = ceil($cntabsolute/$this->_pDataViewAddress->getRecordsPerPage());
 
 		$multipage = $numpages > 1;
 		$more = true;
@@ -546,6 +619,9 @@ implements AddressListBase
 	 */
 	public function getAddressOverallCount()
 	{
+		if ($this->_geoFilteredCount !== null) {
+			return $this->_geoFilteredCount;
+		}
 		return $this->_pApiClientAction->getResultMeta()['cntabsolute'];
 	}
 

--- a/plugin/AddressList.php
+++ b/plugin/AddressList.php
@@ -270,8 +270,6 @@ implements AddressListBase
 			$geoSearch = sanitize_text_field( wp_unslash( $_GET['geo_search'] ) );
 			$geoCoords = explode( ',', $geoSearch );
 			if ( count( $geoCoords ) === 2 ) {
-				$filter['geo'][0]['op'] = $filter['geo'][0]['op'] ?? 'geo';
-				$filter['geo'][0]['val'] = $filter['geo'][0]['val'] ?? 200;
 				$filter['geo'][0]['loc'] = $geoSearch;
 			}
 		}
@@ -366,7 +364,6 @@ implements AddressListBase
 		$pSDKWrapper->sendRequests();
 		$result = $this->_pApiClientAction->getResult();
 		$this->_records = $result["data"]["records"];
-
 		$recordsRaw = $pApiClientActionRaw->getResultRecords();
 
 		$this->fetchEstatesForAddressIds($this->getAddressIds());

--- a/plugin/AddressList.php
+++ b/plugin/AddressList.php
@@ -373,13 +373,11 @@ implements AddressListBase
 		$this->_records = $result["data"]["records"];
 		$recordsRaw = $pApiClientActionRaw->getResultRecords();
 
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Geo search is a public filter, no nonce needed
-		if (isset($_GET['geo_search'])) {
+		if (isset($parameters['filter']['geo'][0]['loc'])) {
 			$perPage = $this->_pDataViewAddress->getRecordsPerPage();
 			$offset = ($newPage - 1) * $perPage;
 			$this->_records = array_slice($this->_records, $offset, $perPage);
 		}
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		$this->fetchEstatesForAddressIds($this->getAddressIds());
 		$this->fillAddressesById($this->_records);

--- a/plugin/AddressList.php
+++ b/plugin/AddressList.php
@@ -266,14 +266,21 @@ implements AddressListBase
 		}
 
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Geo search is a public filter, no nonce needed
+		$hasGeoSearch = false;
 		if ( isset( $_GET['geo_search'] ) ) {
 			$geoSearch = sanitize_text_field( wp_unslash( $_GET['geo_search'] ) );
 			$geoCoords = explode( ',', $geoSearch );
 			if ( count( $geoCoords ) === 2 ) {
 				$filter['geo'][0]['loc'] = $geoSearch;
+				$hasGeoSearch = true;
 			}
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		if ($hasGeoSearch) {
+			$offset = 0;
+			$numRecordsPerPage = 500;
+		}
 
 		$parameters = array(
 			'data' => $pFieldModifierHandler->getAllAPIFields(),

--- a/plugin/AddressList.php
+++ b/plugin/AddressList.php
@@ -276,6 +276,9 @@ implements AddressListBase
 			}
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+		if (!$hasGeoSearch) {
+			unset($filter['geo']);
+		}
 
 		if ($hasGeoSearch) {
 			$offset = 0;

--- a/plugin/AddressList.php
+++ b/plugin/AddressList.php
@@ -373,6 +373,14 @@ implements AddressListBase
 		$this->_records = $result["data"]["records"];
 		$recordsRaw = $pApiClientActionRaw->getResultRecords();
 
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Geo search is a public filter, no nonce needed
+		if (isset($_GET['geo_search'])) {
+			$perPage = $this->_pDataViewAddress->getRecordsPerPage();
+			$offset = ($newPage - 1) * $perPage;
+			$this->_records = array_slice($this->_records, $offset, $perPage);
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
 		$this->fetchEstatesForAddressIds($this->getAddressIds());
 		$this->fillAddressesById($this->_records);
 		$this->_recordsRaw = array_combine(array_column($recordsRaw, 'id'), $recordsRaw);

--- a/plugin/Cache/DBCache.php
+++ b/plugin/Cache/DBCache.php
@@ -89,11 +89,18 @@ class DBCache
 		$parametersSerialized = $this->getParametersSerialized( $parameters );
 		if(isset($parameters['parameters']['listname']))
 		{
-			$parametersSerialized = $parameters['parameters']['listname'].intval($parameters['parameters']['formatoutput']).$parameters['parameters']['outputlanguage'];
-			// Append ID filters to the cache key to guarantee uniqueness for identity-based lists (like unit lists with sub-estates).
-			if (isset($parameters['parameters']['filter']['Id'])) {
-				$parametersSerialized .= serialize($parameters['parameters']['filter']['Id']);
+			$hashParts = [
+				$parameters['parameters']['listname'],
+				intval($parameters['parameters']['formatoutput']),
+				$parameters['parameters']['outputlanguage'],
+			];
+
+			$filter = $parameters['parameters']['filter'] ?? [];
+			if (is_array($filter) && count($filter) > 0) {
+				$hashParts[] = serialize($filter);
 			}
+
+			$parametersSerialized = implode('|', $hashParts);
 		}
 		return md5( $parametersSerialized );
 	}

--- a/plugin/EstateList.php
+++ b/plugin/EstateList.php
@@ -839,6 +839,9 @@ class EstateList
 			}
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+		if (!$hasGeoSearch) {
+			unset($filter['geo']);
+		}
 
 		if ($hasGeoSearch) {
 			$numRecordsPerPage = 500;

--- a/plugin/EstateList.php
+++ b/plugin/EstateList.php
@@ -372,13 +372,11 @@ class EstateList
 		$recordsRaw = $pApiClientActionRawValues->getResultRecords();
 		$this->_recordsRaw = array_combine(array_column($recordsRaw, 'id'), $recordsRaw);
 
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Geo search pagination
-		if (isset($_GET['geo_search'])) {
+		if (isset($estateParameters['filter']['geo'][0]['loc'])) {
 			$perPage = $this->getRecordsPerPage();
 			$offset = ($currentPage - 1) * $perPage;
 			$this->_records = array_slice($this->_records, $offset, $perPage);
 		}
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 	}
 
 	/**

--- a/plugin/EstateList.php
+++ b/plugin/EstateList.php
@@ -371,6 +371,14 @@ class EstateList
 		$this->_records = $this->_pApiClientAction->getResultRecords();
 		$recordsRaw = $pApiClientActionRawValues->getResultRecords();
 		$this->_recordsRaw = array_combine(array_column($recordsRaw, 'id'), $recordsRaw);
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Geo search pagination
+		if (isset($_GET['geo_search'])) {
+			$perPage = $this->getRecordsPerPage();
+			$offset = ($currentPage - 1) * $perPage;
+			$this->_records = array_slice($this->_records, $offset, $perPage);
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 	}
 
 	/**
@@ -854,7 +862,7 @@ class EstateList
 		}
 
 		if (!$pListView->getRandom()) {
-			$offset = ($currentPage - 1) * $numRecordsPerPage;
+			$offset = $hasGeoSearch ? 0 : ($currentPage - 1) * $numRecordsPerPage;
 			$this->_currentEstatePage = $currentPage;
 			$requestParams += [
 				'listoffset' => $offset

--- a/plugin/EstateList.php
+++ b/plugin/EstateList.php
@@ -823,14 +823,20 @@ class EstateList
 		);
 		
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Geo search is a public filter, no nonce needed
+		$hasGeoSearch = false;
 		if ( isset( $_GET['geo_search'] ) ) {
 			$geoSearch = sanitize_text_field( wp_unslash( $_GET['geo_search'] ) );
 			$geoCoords = explode( ',', $geoSearch );
 			if ( count( $geoCoords ) === 2 ) {
 				$filter['geo'][0]['loc'] = $geoSearch;
+				$hasGeoSearch = true;
 			}
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		if ($hasGeoSearch) {
+			$numRecordsPerPage = 500;
+		}
 
 		$requestParams = [
 			'data' => $pFieldModifierHandler->getAllAPIFields(),

--- a/tests/TestClassAddressList.php
+++ b/tests/TestClassAddressList.php
@@ -737,6 +737,48 @@ class TestClassAddressList
 		return json_decode($responseStr, true);
 	}
 
+	public function testGetAddressParametersEmptyGeoSearchUsesRegularPagination()
+	{
+		$originalGet = $_GET;
+		$_GET['geo_search'] = '';
+
+		try {
+			$this->_pEnvironment->getFieldnames()->loadLanguage();
+			$getAddressParameters = Closure::bind(function (int $currentPage, bool $formatOutput) {
+				return $this->getAddressParameters($currentPage, $formatOutput);
+			}, $this->_pAddressList, AddressList::class);
+
+			$params = $getAddressParameters(2, true);
+
+			$this->assertSame(5, $params['listlimit']);
+			$this->assertSame(5, $params['listoffset']);
+			$this->assertArrayNotHasKey('geo', $params['filter']);
+		} finally {
+			$_GET = $originalGet;
+		}
+	}
+
+	public function testGetAddressParametersValidGeoSearchFetchesAllAndKeepsApiOffsetZero()
+	{
+		$originalGet = $_GET;
+		$_GET['geo_search'] = '7.0,51.0';
+
+		try {
+			$this->_pEnvironment->getFieldnames()->loadLanguage();
+			$getAddressParameters = Closure::bind(function (int $currentPage, bool $formatOutput) {
+				return $this->getAddressParameters($currentPage, $formatOutput);
+			}, $this->_pAddressList, AddressList::class);
+
+			$params = $getAddressParameters(2, true);
+
+			$this->assertSame(500, $params['listlimit']);
+			$this->assertSame(0, $params['listoffset']);
+			$this->assertSame('7.0,51.0', $params['filter']['geo'][0]['loc']);
+		} finally {
+			$_GET = $originalGet;
+		}
+	}
+
 	private function getResponseGetRowsRaw()
 	{
 		$responseStr = '

--- a/tests/TestClassDBCache.php
+++ b/tests/TestClassDBCache.php
@@ -1,0 +1,203 @@
+<?php
+
+/**
+ *
+ *    Copyright (C) 2019 onOffice GmbH
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Affero General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare (strict_types=1);
+
+namespace onOffice\tests;
+
+use onOffice\WPlugin\Cache\DBCache;
+use ReflectionMethod;
+use WP_UnitTestCase;
+
+
+/**
+ *
+ * @covers onOffice\WPlugin\Cache\DBCache
+ *
+ */
+
+class TestClassDBCache
+	extends WP_UnitTestCase
+{
+	/**
+	 * Different filters should produce different cache keys.
+	 * Before the fix, only the Id filter was included in the hash.
+	 */
+	public function testGetParametersHashed_differentFiltersDifferentKeys()
+	{
+		$pDBCache = new DBCache(['ttl' => 3600]);
+		$method = new ReflectionMethod(DBCache::class, 'getParametersHashed');
+		$method->setAccessible(true);
+
+		$paramsA = [
+			'parameters' => [
+				'listname' => 'test',
+				'formatoutput' => true,
+				'outputlanguage' => 'ENG',
+				'filter' => [
+					'kaufpreis' => [['op' => '>=', 'val' => 100000]],
+				],
+			],
+		];
+
+		$paramsB = [
+			'parameters' => [
+				'listname' => 'test',
+				'formatoutput' => true,
+				'outputlanguage' => 'ENG',
+				'filter' => [
+					'kaufpreis' => [['op' => '>=', 'val' => 200000]],
+				],
+			],
+		];
+
+		$keyA = $method->invoke($pDBCache, $paramsA);
+		$keyB = $method->invoke($pDBCache, $paramsB);
+
+		$this->assertNotEquals($keyA, $keyB);
+	}
+
+
+	/**
+	 * Same listname, formatoutput, language, and filter should produce the same cache key.
+	 */
+	public function testGetParametersHashed_sameParamsSameKey()
+	{
+		$pDBCache = new DBCache(['ttl' => 3600]);
+		$method = new ReflectionMethod(DBCache::class, 'getParametersHashed');
+		$method->setAccessible(true);
+
+		$params = [
+			'parameters' => [
+				'listname' => 'test',
+				'formatoutput' => true,
+				'outputlanguage' => 'ENG',
+				'filter' => [
+					'kaufpreis' => [['op' => '>=', 'val' => 100000]],
+				],
+			],
+		];
+
+		$key1 = $method->invoke($pDBCache, $params);
+		$key2 = $method->invoke($pDBCache, $params);
+
+		$this->assertEquals($key1, $key2);
+	}
+
+
+	/**
+	 * Adding a geo filter should change the cache key.
+	 */
+	public function testGetParametersHashed_geoFilterChangesKey()
+	{
+		$pDBCache = new DBCache(['ttl' => 3600]);
+		$method = new ReflectionMethod(DBCache::class, 'getParametersHashed');
+		$method->setAccessible(true);
+
+		$paramsWithoutGeo = [
+			'parameters' => [
+				'listname' => 'test',
+				'formatoutput' => true,
+				'outputlanguage' => 'ENG',
+				'filter' => [
+					'kaufpreis' => [['op' => '>=', 'val' => 100000]],
+				],
+			],
+		];
+
+		$paramsWithGeo = [
+			'parameters' => [
+				'listname' => 'test',
+				'formatoutput' => true,
+				'outputlanguage' => 'ENG',
+				'filter' => [
+					'kaufpreis' => [['op' => '>=', 'val' => 100000]],
+					'geo' => [['op' => 'geo', 'val' => 10, 'loc' => '7.0,51.0']],
+				],
+			],
+		];
+
+		$keyWithoutGeo = $method->invoke($pDBCache, $paramsWithoutGeo);
+		$keyWithGeo = $method->invoke($pDBCache, $paramsWithGeo);
+
+		$this->assertNotEquals($keyWithoutGeo, $keyWithGeo);
+	}
+
+
+	/**
+	 * Empty filter array should produce a different key than a populated filter.
+	 */
+	public function testGetParametersHashed_emptyFilterDifferentFromPopulatedFilter()
+	{
+		$pDBCache = new DBCache(['ttl' => 3600]);
+		$method = new ReflectionMethod(DBCache::class, 'getParametersHashed');
+		$method->setAccessible(true);
+
+		$paramsEmptyFilter = [
+			'parameters' => [
+				'listname' => 'test',
+				'formatoutput' => true,
+				'outputlanguage' => 'ENG',
+				'filter' => [],
+			],
+		];
+
+		$paramsPopulatedFilter = [
+			'parameters' => [
+				'listname' => 'test',
+				'formatoutput' => true,
+				'outputlanguage' => 'ENG',
+				'filter' => [
+					'kaufpreis' => [['op' => '>=', 'val' => 100000]],
+				],
+			],
+		];
+
+		$keyEmpty = $method->invoke($pDBCache, $paramsEmptyFilter);
+		$keyPopulated = $method->invoke($pDBCache, $paramsPopulatedFilter);
+
+		$this->assertNotEquals($keyEmpty, $keyPopulated);
+	}
+
+
+	/**
+	 * Without listname, falls back to full serialization.
+	 */
+	public function testGetParametersHashed_withoutListnameUsesFullSerialization()
+	{
+		$pDBCache = new DBCache(['ttl' => 3600]);
+		$method = new ReflectionMethod(DBCache::class, 'getParametersHashed');
+		$method->setAccessible(true);
+
+		$params = [
+			'parameters' => [
+				'formatoutput' => true,
+				'outputlanguage' => 'ENG',
+			],
+		];
+
+		$key = $method->invoke($pDBCache, $params);
+
+		$this->assertNotEmpty($key);
+		$this->assertIsString($key);
+		$this->assertEquals(32, strlen($key));
+	}
+}

--- a/tests/TestClassEstateList.php
+++ b/tests/TestClassEstateList.php
@@ -1324,6 +1324,46 @@ class TestClassEstateList
 		}
 	}
 
+	public function testGetEstateParametersEmptyGeoSearchUsesRegularPagination()
+	{
+		$originalGet = $_GET;
+		$_GET['geo_search'] = '';
+
+		try {
+			$getEstateParameters = Closure::bind(function (int $currentPage, bool $formatOutput) {
+				return $this->getEstateParameters($currentPage, $formatOutput);
+			}, $this->_pEstateList, EstateList::class);
+
+			$params = $getEstateParameters(2, true);
+
+			$this->assertSame(5, $params['listlimit']);
+			$this->assertSame(5, $params['listoffset']);
+			$this->assertArrayNotHasKey('geo', $params['filter']);
+		} finally {
+			$_GET = $originalGet;
+		}
+	}
+
+	public function testGetEstateParametersValidGeoSearchFetchesAllAndKeepsApiOffsetZero()
+	{
+		$originalGet = $_GET;
+		$_GET['geo_search'] = '7.0,51.0';
+
+		try {
+			$getEstateParameters = Closure::bind(function (int $currentPage, bool $formatOutput) {
+				return $this->getEstateParameters($currentPage, $formatOutput);
+			}, $this->_pEstateList, EstateList::class);
+
+			$params = $getEstateParameters(2, true);
+
+			$this->assertSame(500, $params['listlimit']);
+			$this->assertSame(0, $params['listoffset']);
+			$this->assertSame('7.0,51.0', $params['filter']['geo'][0]['loc']);
+		} finally {
+			$_GET = $originalGet;
+		}
+	}
+
 	/**
 	 *
 	 * @return FieldsCollection


### PR DESCRIPTION
The geo filter was completely broken: it never actually filtered results by distance and always returned the full, unfiltered result set regardless of the search radius.

### Root causes

- **Inverted coordinates in distance calculation:** `Coordinate(latitude, longitude)` was called with `(longitude, latitude)`, causing all distance calculations to be wildly off.
- **Result set too small for client-side filtering:** The API only returned the default page size (~20 records). Geo filtering is applied client-side on the full result set, so it had too few records to produce meaningful results.
- **Cache key collisions:** The cache key only included the `Id` filter, so changing geo or other filters would reuse a stale cached response.
- **Missing raw/types data blocks:** `filterRecords` assumed `raw.data.records` and `types` were always present, but geo-filtered responses from the cache don"t include them.

### Changes

**SDK - Coordinate order (`SDK/src/internal/ApiCall.php`)**
- Changed `Coordinate(lng, lat)` to `Coordinate(lat, lng)` - the first argument to `Coordinate` is latitude, not longitude.

**SDK - Null-safe and auto-generated data (`SDK/src/internal/ApiCall.php`)**
- Added null-coalescing for `min`/`max` keys in geo filter arrays.
- `filterRecords` now auto-generates `raw.data.records` and `types` when missing from the response.

**SDK - Fresh response geo filtering (`SDK/src/internal/ApiCall.php`)**
- New `applyFreshGeoFiltering` method applies client-side geo filtering to fresh responses (not just cached ones) after they are written to cache.

**SDK - Geo bypass for structure validation (`SDK/src/internal/ApiCall.php`)**
- `applyListCacheFiltering` skips `raw.data.records`/`types` validation when a geo filter is present, since those structures are only needed for non-geo filtering.

**Cache - All filters in cache key (`plugin/Cache/DBCache.php`)**
- Cache key now includes all filter parameters (serialized), not just `Id`. Prevents stale cache hits when filters change.

**List views - Full result sets (`plugin/EstateList.php`, `plugin/AddressList.php`)**
- When `geo_search` is present, `numRecordsPerPage` is increased to 500 to fetch the maximum possible records for client-side distance filtering.
- AddressList additionally resets the offset and applies pagination slicing after filtering.

### Tests

- `SDK/tests/ApiCallTest.php`: 5 new tests covering coordinate order, missing raw/types generation, null-safe min/max, geo bypass logic, and geo distance filtering.
- `tests/TestClassDBCache.php`: New file with 5 tests covering cache key determinism, filter-aware keys, and geo filter inclusion.