### PR TITLE
feat(P#167885): Umziehen des oo-updateservers auf Ionos

### DIFF
--- a/.github/workflows/oo-wp-updates-release-dev.yml
+++ b/.github/workflows/oo-wp-updates-release-dev.yml
@@ -1,0 +1,118 @@
+name: onOffice WP-Updates Release (Dev Update Server)
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  get-version:
+    name: Get current version
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.release.prerelease }}
+    outputs:
+      currentVersion: ${{ steps.get-version.outputs.version }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Get version
+        id: get-version
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Update-server deploys require a final semantic version tag like v6.16.0. Got: ${TAG_NAME}"
+            exit 1
+          fi
+
+          VERSION="${TAG_NAME#v}"
+
+          grep -Eq "^Version:[[:space:]]+${VERSION}$" plugin.php
+          grep -Eq "^const ONOFFICE_PLUGIN_VERSION = '${VERSION}';$" plugin.php
+          grep -Eq "^Stable tag:[[:space:]]+${VERSION}$" readme.txt
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build release
+    needs: get-version
+    uses: ./.github/workflows/build-release.yml
+    with:
+      ref: ${{ github.event.release.tag_name }}
+      expectedVersion: ${{ needs.get-version.outputs.currentVersion }}
+      checkVersion: false
+      pluginFolder: onoffice-for-wp-websites
+
+  deploy:
+    name: Deploy to Dev Update Server
+    runs-on: ubuntu-latest
+    needs: [get-version, build]
+    steps:
+      - name: Checkout source (for readme.txt)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          path: source
+
+      - name: Download release artifact
+        uses: actions/download-artifact@v4.1.7
+        with:
+          name: release
+
+      - name: Extract metadata from readme.txt
+        id: readme-meta
+        run: |
+          README="source/readme.txt"
+          if [ ! -f "$README" ]; then
+            echo "readme.txt not found at $README" >&2
+            exit 1
+          fi
+
+          # Read the standard WordPress plugin readme headers. They look like:
+          #   Requires PHP: 8.2
+          #   Requires at least: 6.1
+          #   Tested up to: 6.9
+          extract() {
+            grep -i -m1 "^$1:" "$README" | sed -E "s/^[^:]+:[[:space:]]*//" | tr -d '\r' | xargs
+          }
+
+          REQUIRES_PHP="$(extract 'Requires PHP')"
+          REQUIRES_WP="$(extract 'Requires at least')"
+          TESTED_WP="$(extract 'Tested up to')"
+
+          if [ -z "$REQUIRES_PHP" ]; then
+            echo "Could not parse 'Requires PHP' from readme.txt" >&2
+            exit 1
+          fi
+
+          echo "requires_php=$REQUIRES_PHP" >> $GITHUB_OUTPUT
+          echo "requires=$REQUIRES_WP"     >> $GITHUB_OUTPUT
+          echo "tested=$TESTED_WP"         >> $GITHUB_OUTPUT
+
+          echo "Parsed: requires_php=$REQUIRES_PHP requires=$REQUIRES_WP tested=$TESTED_WP"
+
+      - name: Deployment final release json Updater File
+        id: create-json
+        uses: jsdaniell/create-json@v1.2.2
+        with:
+          name: "updater.json"
+          json: '{"version":"${{ needs.get-version.outputs.currentVersion }}","download_url":"https://dev.onoffice-wp-updates.de/plugins/oo-wp-plugin/release.zip","requires_php":"${{ steps.readme-meta.outputs.requires_php }}","requires":"${{ steps.readme-meta.outputs.requires }}","tested":"${{ steps.readme-meta.outputs.tested }}"}'
+
+      - name: Upload release build
+        uses: actions/upload-artifact@v4
+        with:
+          name: oo-wp-plugin Release Bundle (Dev)
+          path: |
+            release.zip
+            updater.json
+          retention-days: 7
+
+      - name: Set SSH Key for Dev Update Server
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_UPDATE_SERVER }}
+
+      - name: Upload Files to Dev Update Server
+        run: rsync -e 'ssh -o StrictHostKeyChecking=no' release.zip updater.json zipupload@dev.onoffice-wp-updates.de:plugins/oo-wp-plugin

--- a/.github/workflows/oo-wp-updates-release-dev.yml
+++ b/.github/workflows/oo-wp-updates-release-dev.yml
@@ -109,7 +109,7 @@ jobs:
         uses: jsdaniell/create-json@v1.2.2
         with:
           name: "updater.json"
-          json: '{"version":"${{ needs.get-version.outputs.currentVersion }}","download_url":"https://dev.onoffice-wp-updates.de/plugins/oo-wp-plugin/release.zip","requires_php":"${{ steps.readme-meta.outputs.requires_php }}","requires":"${{ steps.readme-meta.outputs.requires }}","tested":"${{ steps.readme-meta.outputs.tested }}"}'
+          json: '{"version":"${{ needs.get-version.outputs.currentVersion }}","download_url":"https://dev.onoffice-wp-updates.de/releases/plugins/oo-wp-plugin/release.zip","requires_php":"${{ steps.readme-meta.outputs.requires_php }}","requires":"${{ steps.readme-meta.outputs.requires }}","tested":"${{ steps.readme-meta.outputs.tested }}"}'
 
       - name: Upload release build
         uses: actions/upload-artifact@v4

--- a/.github/workflows/oo-wp-updates-release-dev.yml
+++ b/.github/workflows/oo-wp-updates-release-dev.yml
@@ -3,24 +3,35 @@ name: onOffice WP-Updates Release (Dev Update Server)
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release tag to redeploy to the dev update server (e.g. v6.16.0)"
+        required: true
+        type: string
 
 jobs:
   get-version:
     name: Get current version
     runs-on: ubuntu-latest
-    if: ${{ !github.event.release.prerelease }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
     outputs:
       currentVersion: ${{ steps.get-version.outputs.version }}
+      tagName: ${{ steps.tag.outputs.tag }}
     steps:
+      - name: Determine release tag
+        id: tag
+        run: echo "tag=${{ github.event.inputs.release_tag || github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout release tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ steps.tag.outputs.tag }}
 
       - name: Get version
         id: get-version
         env:
-          TAG_NAME: ${{ github.event.release.tag_name }}
+          TAG_NAME: ${{ steps.tag.outputs.tag }}
         run: |
           if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Update-server deploys require a final semantic version tag like v6.16.0. Got: ${TAG_NAME}"
@@ -40,7 +51,7 @@ jobs:
     needs: get-version
     uses: ./.github/workflows/build-release.yml
     with:
-      ref: ${{ github.event.release.tag_name }}
+      ref: ${{ needs.get-version.outputs.tagName }}
       expectedVersion: ${{ needs.get-version.outputs.currentVersion }}
       checkVersion: false
       pluginFolder: onoffice-for-wp-websites
@@ -53,7 +64,7 @@ jobs:
       - name: Checkout source (for readme.txt)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ needs.get-version.outputs.tagName }}
           path: source
 
       - name: Download release artifact


### PR DESCRIPTION
Adds a second, parallel onOffice WP-Updates release workflow that publishes to dev.onoffice-wp-updates.de (new IONOS-hosted update server) alongside the existing Raidboxes release workflow.