### PR TITLE
fix(P170435): fix-map

### DIFF
--- a/plugin/EstateList.php
+++ b/plugin/EstateList.php
@@ -1171,11 +1171,6 @@ class EstateList
 			elseif (isset($recordRaw['showGoogleMap']) && ($recordRaw['showGoogleMap'] === '1' || $recordRaw['showGoogleMap'] === 1 || $recordRaw['showGoogleMap'] === true)) {
 				$recordModified['showGoogleMap'] = true;
 			}
-			else {
-				// No explicit per-estate override (raw value missing/empty) -> fall back
-				// to the list-level "show map" setting, as done before P#165597.
-				$recordModified['showGoogleMap'] = $this->getShowMapConfig();
-			}
 		}
 
 		if ($checkEstateIdRequestGuard && $this->_pWPOptionWrapper->getOption('onoffice-settings-title-and-description') == 0) {

--- a/plugin/EstateList.php
+++ b/plugin/EstateList.php
@@ -528,6 +528,19 @@ class EstateList
 			'land',
 			'virtualAddress',
             'referenz',
+			// Needed by EstateViewFieldModifierTypeEstateGeoBase::reduceRecord() to decide
+			// whether breitengrad/laengengrad should be zeroed out or replaced with the
+			// virtual-address coordinates. Without these, the missing keys are treated as
+			// falsy and the real coordinates get zeroed for every estate (P#165597 regression).
+			'objektadresse_freigeben_api',
+			'virtualLatitude',
+			'virtualLongitude',
+			'virtualStreet',
+			'virtualHouseNumber',
+			// Needed so estateIterator()'s MODIFIER_TYPE_MAP branch can read
+			// $recordRaw['showGoogleMap'] — without it isset() never passes and
+			// $recordModified['showGoogleMap'] is left unset for every estate.
+			'showGoogleMap',
 		];
 
 		$requestParams = [
@@ -1151,13 +1164,18 @@ class EstateList
 		}
 
 		if ($modifier === EstateViewFieldModifierTypes::MODIFIER_TYPE_MAP && $this->_pDataView instanceof DataListView) {
-    
+
 			if (isset($recordRaw['showGoogleMap']) && ($recordRaw['showGoogleMap'] === '0' || $recordRaw['showGoogleMap'] === 0 || $recordRaw['showGoogleMap'] === false)) {
 				$recordModified['showGoogleMap'] = false;
-			} 
+			}
 			elseif (isset($recordRaw['showGoogleMap']) && ($recordRaw['showGoogleMap'] === '1' || $recordRaw['showGoogleMap'] === 1 || $recordRaw['showGoogleMap'] === true)) {
 				$recordModified['showGoogleMap'] = true;
-			} 
+			}
+			else {
+				// No explicit per-estate override (raw value missing/empty) -> fall back
+				// to the list-level "show map" setting, as done before P#165597.
+				$recordModified['showGoogleMap'] = $this->getShowMapConfig();
+			}
 		}
 
 		if ($checkEstateIdRequestGuard && $this->_pWPOptionWrapper->getOption('onoffice-settings-title-and-description') == 0) {

--- a/tests/TestClassEstateList.php
+++ b/tests/TestClassEstateList.php
@@ -946,36 +946,6 @@ class TestClassEstateList
 	}
 
 	/**
-	 * Regression test: when an estate has no explicit per-estate 'showGoogleMap'
-	 * override (raw value missing/empty — the normal case), estateIterator()'s
-	 * MODIFIER_TYPE_MAP branch must fall back to the list-level DataListView::getShowMap()
-	 * setting instead of silently leaving 'showGoogleMap' at its default empty string,
-	 * which made map pins disappear regardless of the list's "show map" setting.
-	 *
-	 */
-	public function testGetShowMapConfigFallsBackToListSettingWhenNoPerEstateOverride()
-	{
-		$this->_pEstateList->loadEstates();
-
-		$pRecordsRawProperty = new ReflectionProperty(EstateList::class, '_recordsRaw');
-		$pRecordsRawProperty->setAccessible(true);
-		$recordsRaw = $pRecordsRawProperty->getValue($this->_pEstateList);
-		foreach ($recordsRaw as &$recordRaw) {
-			$recordRaw['elements']['showGoogleMap'] = '';
-		}
-		unset($recordRaw);
-		$pRecordsRawProperty->setValue($this->_pEstateList, $recordsRaw);
-
-		$this->_pEstateList->resetEstateIterator();
-		$result = $this->_pEstateList->estateIterator(EstateViewFieldModifierTypes::MODIFIER_TYPE_MAP);
-
-		// $result is an ArrayContainerEscape, which stringifies booleans for output —
-		// same reason testGetShowMapConfig() above asserts '1' rather than true.
-		$this->assertEquals('1', $result['showGoogleMap'],
-			'no per-estate override should fall back to DataListView::getShowMap(), which is true in the test fixture');
-	}
-
-	/**
 	 * Regression test for P#165597 and its follow-up bugs: the map request used
 	 * a hardcoded field list that didn't request every field the map-specific
 	 * post-processing in estateIterator() depends on.

--- a/tests/TestClassEstateList.php
+++ b/tests/TestClassEstateList.php
@@ -969,7 +969,9 @@ class TestClassEstateList
 		$this->_pEstateList->resetEstateIterator();
 		$result = $this->_pEstateList->estateIterator(EstateViewFieldModifierTypes::MODIFIER_TYPE_MAP);
 
-		$this->assertTrue($result['showGoogleMap'],
+		// $result is an ArrayContainerEscape, which stringifies booleans for output —
+		// same reason testGetShowMapConfig() above asserts '1' rather than true.
+		$this->assertEquals('1', $result['showGoogleMap'],
 			'no per-estate override should fall back to DataListView::getShowMap(), which is true in the test fixture');
 	}
 

--- a/tests/TestClassEstateList.php
+++ b/tests/TestClassEstateList.php
@@ -61,6 +61,8 @@ use onOffice\WPlugin\Types\FieldsCollection;
 use onOffice\WPlugin\Types\FieldTypes;
 use onOffice\WPlugin\ViewFieldModifier\EstateViewFieldModifierTypes;
 use onOffice\WPlugin\Utility\Redirector;
+use ReflectionMethod;
+use ReflectionProperty;
 use WP_Rewrite;
 use WP_UnitTestCase;
 use function json_decode;
@@ -941,6 +943,76 @@ class TestClassEstateList
 		$this->_pEstateList->loadEstates();
 		$result = $this->_pEstateList->estateIterator(EstateViewFieldModifierTypes::MODIFIER_TYPE_MAP);
 		$this->assertEquals('1', $result['showGoogleMap']);
+	}
+
+	/**
+	 * Regression test: when an estate has no explicit per-estate 'showGoogleMap'
+	 * override (raw value missing/empty — the normal case), estateIterator()'s
+	 * MODIFIER_TYPE_MAP branch must fall back to the list-level DataListView::getShowMap()
+	 * setting instead of silently leaving 'showGoogleMap' at its default empty string,
+	 * which made map pins disappear regardless of the list's "show map" setting.
+	 *
+	 */
+	public function testGetShowMapConfigFallsBackToListSettingWhenNoPerEstateOverride()
+	{
+		$this->_pEstateList->loadEstates();
+
+		$pRecordsRawProperty = new ReflectionProperty(EstateList::class, '_recordsRaw');
+		$pRecordsRawProperty->setAccessible(true);
+		$recordsRaw = $pRecordsRawProperty->getValue($this->_pEstateList);
+		foreach ($recordsRaw as &$recordRaw) {
+			$recordRaw['elements']['showGoogleMap'] = '';
+		}
+		unset($recordRaw);
+		$pRecordsRawProperty->setValue($this->_pEstateList, $recordsRaw);
+
+		$this->_pEstateList->resetEstateIterator();
+		$result = $this->_pEstateList->estateIterator(EstateViewFieldModifierTypes::MODIFIER_TYPE_MAP);
+
+		$this->assertTrue($result['showGoogleMap'],
+			'no per-estate override should fall back to DataListView::getShowMap(), which is true in the test fixture');
+	}
+
+	/**
+	 * Regression test for P#165597 and its follow-up bugs: the map request used
+	 * a hardcoded field list that didn't request every field the map-specific
+	 * post-processing in estateIterator() depends on.
+	 *
+	 * - EstateViewFieldModifierTypeEstateGeoBase::reduceRecord() treats a missing
+	 *   'objektadresse_freigeben_api' as falsy (0 == null) and zeroes out the
+	 *   real breitengrad/laengengrad coordinates for every estate.
+	 * - EstateList::estateIterator()'s MODIFIER_TYPE_MAP branch only overrides
+	 *   $recordModified['showGoogleMap'] when the raw value is an explicit '0'/'1' —
+	 *   if 'showGoogleMap' is never fetched, isset() is always false and the flag
+	 *   silently stays at its default empty string for every estate.
+	 *
+	 * This asserts the map's API request actually includes every field those
+	 * two code paths depend on.
+	 *
+	 */
+	public function testGetEstateParametersForMapRequestsGeoReductionFields()
+	{
+		$pReflectionMethod = new ReflectionMethod(EstateList::class, 'getEstateParametersForMap');
+		$pReflectionMethod->setAccessible(true);
+		$result = $pReflectionMethod->invokeArgs($this->_pEstateList, [1, true]);
+
+		$requiredFields = [
+			'breitengrad',
+			'laengengrad',
+			'virtualAddress',
+			'objektadresse_freigeben_api',
+			'virtualLatitude',
+			'virtualLongitude',
+			'virtualStreet',
+			'virtualHouseNumber',
+			'showGoogleMap',
+		];
+
+		foreach ($requiredFields as $requiredField) {
+			$this->assertContains($requiredField, $result['data'],
+				"map request is missing '$requiredField', needed by estateIterator()'s "
+				.'MODIFIER_TYPE_MAP post-processing (geo reduction and/or showGoogleMap)');
+		}
 	}
 
 	/**


### PR DESCRIPTION
# Karte wird nicht angezeigt

## Problematische Commits

Die beiden Commits die in Kombination zum Problem führen sind: [Commit1](https://github.com/onOffice-Web-Org/oo-wp-plugin/commit/62355b8e69c83999b0f6a32058a965b7b702e6a8) [Commit2](https://github.com/onOffice-Web-Org/onoffice-classic/commit/81465f51279902c549696235e30fc3cf7645eaf5).

## Hintergrund

Für die Kartenansicht der Immobilienliste wird eine eigene, schlanke `EstateList`
über `EstateList::getEstateListForMap()` geladen (`plugin/EstateList.php`).
Diese verwendet für den API-Request bewusst eine **fest hinterlegte, kleinere
Feldliste** (`getEstateParametersForMap()`), statt wie die reguläre Liste alle
Felder dynamisch über `ViewFieldModifierHandler::getAllAPIFields()` zu ermitteln
— aus Performance-Gründen, damit für die Karte nicht unnötig viele Felder pro
Immobilie geladen werden.

Diese fest hinterlegte Liste ist an keiner Stelle strukturell mit den Feldern
verknüpft, die die nachgelagerte Kartenlogik in `EstateList::estateIterator()`
und `EstateViewFieldModifierTypeEstateGeoBase::reduceRecord()` tatsächlich
benötigt. Genau das hat einen Bug verursacht.

## Bug: `breitengrad` / `laengengrad` werden auf 0 gesetzt

`EstateViewFieldModifierTypeEstateGeoBase::reduceRecord()` prüft für jede
Immobilie das Feld `objektadresse_freigeben_api`:

```php
} elseif (0 == $record['objektadresse_freigeben_api'] || ...) {
    $record['laengengrad'] = 0;
    $record['breitengrad'] = 0;
}
```

Dieses Feld — sowie `virtualLatitude`, `virtualLongitude`, `virtualStreet`,
`virtualHouseNumber` für den virtuellen-Adresse-Zweig — fehlte in der
hartkodierten `$mapFields`-Liste. Dadurch war `$record['objektadresse_freigeben_api']`
schlicht nicht gesetzt (`null`), und PHPs laxer Vergleich `0 == null` ist
`true` — der "Adresse nicht freigegeben"-Zweig griff also für **jede**
Immobilie, unabhängig vom tatsächlichen Freigabestatus, und hat die korrekt
geladenen Koordinaten wieder auf `0`/`0` überschrieben.

**Wie es entstanden ist:** Zwei für sich genommen korrekte Commits haben sich
überschnitten. Ein Commit hat die separate, schlanke Feldliste für die Karte
eingeführt. Ein zweiter, zwei Tage später gemergter Commit hat das Feld
`objektadresse_freigeben` in `objektadresse_freigeben_api` umbenannt — und
dabei alle Stellen aktualisiert, die ihre Feldliste dynamisch über
`getAllAPIFields()` aufbauen (das betrifft die reguläre Liste, die deshalb
weiterhin korrekt funktionierte). Die hartkodierte Kartenliste hängt an keiner
dieser dynamischen Stellen und wurde entsprechend nicht mitgezogen — weder vor
noch nach der Umbenennung enthielt sie das benötigte Feld, nur der Fehler
wurde dadurch sichtbar.

## Der Fix

Das Problem wurde gezielt und ohne größere Restrukturierung behoben:

1. **`getEstateParametersForMap()`**: Die fehlenden Felder
   (`objektadresse_freigeben_api`, `virtualLatitude`, `virtualLongitude`,
   `virtualStreet`, `virtualHouseNumber`, `showGoogleMap`) wurden zur
   hartkodierten `$mapFields`-Liste ergänzt, mit Kommentar, wofür sie jeweils
   gebraucht werden.

## Tests

- Neuer Test prüft, dass `getEstateParametersForMap()` alle Felder anfragt,
  von denen die Karten-Nachverarbeitung (Geo-Reduktion und `showGoogleMap`)
  abhängt.
